### PR TITLE
Spelling fix: conocurse -> concourse

### DIFF
--- a/lit/setting-up/installing.lit
+++ b/lit/setting-up/installing.lit
@@ -327,7 +327,7 @@ a tool that meshes well with Concourse's ideals, buckle up and head over to
       depends_on: [concourse-db]
       ports: ["8080:8080"]
       volumes: ["./keys/web:/concourse-keys"]
-      restart: unless-stopped # required so that it retries until conocurse-db comes up
+      restart: unless-stopped # required so that it retries until concourse-db comes up
       environment:
         CONCOURSE_BASIC_AUTH_USERNAME: concourse
         CONCOURSE_BASIC_AUTH_PASSWORD: changeme


### PR DESCRIPTION
Just a small typo in the `docker-compose.yml` example.