### PR TITLE
Update url in how to add 3rd party resources

### DIFF
--- a/lit/using-concourse/resource-types.lit
+++ b/lit/using-concourse/resource-types.lit
@@ -222,9 +222,9 @@ before using it!
     \title{Adding to this list}
 
     Fork the
-    \link{\code{concourse/concourse}}{https://github.com/concourse/concourse}
+    \link{\code{concourse/concourse}}{https://github.com/concourse/docs}
     repository, edit
-    \code{concourse/docs/lit/using-concourse/resource-types.lit},
+    \code{lit/using-concourse/resource-types.lit},
     then make a pull request.
   }
 }


### PR DESCRIPTION
The docs where moved to a new repo[1] so the instructions
are now wrong. Fixing.

[1] https://github.com/concourse/concourse/commit/01ed4d8c3860afeaa3cd1bc316297d68e9626e1c