### PR TITLE
Add link to SonarQube resource

### DIFF
--- a/lit/using-concourse/resource-types.lit
+++ b/lit/using-concourse/resource-types.lit
@@ -218,6 +218,8 @@ before using it!
     \link{Hashicorp Releases}{https://github.com/starkandwayne/hashicorp-release-resource}
   }{
     \link{Pushover notifications}{https://github.com/redfactorlabs/concourse-pushover-resource}
+  }{
+    \link{SonarQube static code analysis}{https://github.com/cathive/concourse-sonarqube-resource}
   }
 
   \section{


### PR DESCRIPTION
This resource can be used to trigger a SonarQube static code analysis (via "sonar-runner") and allows to implement Code quality gates into CI pipelines.