### PR TITLE
Fixed wrong property for db role in sample manifest

### DIFF
--- a/lit/setting-up/installing.lit
+++ b/lit/setting-up/installing.lit
@@ -502,7 +502,7 @@ a tool that meshes well with Concourse's ideals, buckle up and head over to
               database: &atc_db atc
               role: &atc_role
                 # make up a role and password
-                role: REPLACE_ME
+                name: REPLACE_ME
                 password: REPLACE_ME
         - name: tsa
           release: concourse


### PR DESCRIPTION
The role name property for the Postgres database needs to be `name`
[postgres-release customization](https://github.com/cloudfoundry/postgres-release#customizing) 