### PR TITLE
Suggest using PostgreSQL 9.6 for a new installation

### DIFF
--- a/lit/setting-up/installing.lit
+++ b/lit/setting-up/installing.lit
@@ -313,7 +313,7 @@ a tool that meshes well with Concourse's ideals, buckle up and head over to
 
   services:
     concourse-db:
-      image: postgres:9.5
+      image: postgres:9.6
       environment:
         POSTGRES_DB: concourse
         POSTGRES_USER: concourse


### PR DESCRIPTION
Hey,

ATC uses 9.6 since this commit (https://github.com/concourse/atc/commit/a9453f64de38737006a18495bb1ad64a19e6326c). This updates the docs to use PostgreSQL 9.6 for new installations.

Cheers
Ben