### PR TITLE
Call out breaking job spec changes directly in release notes

### DIFF
--- a/lit/release-notes/v3.7.0.lit
+++ b/lit/release-notes/v3.7.0.lit
@@ -26,6 +26,21 @@
   }
 
   \note{feature,breaking}{
+    Some credentials must be provided that were previously generated.
+    
+    Changes to the bosh job specs are as follows:
+    - atc:
+      - added `token_signing_key` (type `rsa`)
+    - tsa:
+      - added `token_signing_key` (must equal `atc.token_signing_key`)
+      - added `host_key` (type `ssh`, replaces existing `host_key` which was just the private key)
+      - removed `host_public_key`
+      - removed `athorize_generated_worker_key`
+      - `authorized_keys` must now contain all workers' `groundcrew.tsa.worker_key`s
+    - groundcrew:
+      - `tsa.worker_key` (type: `ssh` replaces `tsa.private_key`)
+      
+  
     Our BOSH release used to have a few magical mystical packages called
     \code{generated_something}. These packages would generate a RSA key every
     time they compiled, in service of automagically wiring up security


### PR DESCRIPTION
It's not really clear from reading the release note entry what (or even that) manifest changes are necessary. The explanation of why the change was made is cute but not critical, and should not detract from making critical information explicit.