### PR TITLE
setting up: use same Postgres database name everywhere

### DIFF
--- a/lit/setting-up/installing/binary.lit
+++ b/lit/setting-up/installing/binary.lit
@@ -148,7 +148,7 @@ hand or orchestrating it with Docker, Chef, or other ops tooling.
       --session-signing-key session_signing_key \\
       --tsa-host-key tsa_host_key \\
       --tsa-authorized-keys authorized_worker_keys \\
-      --postgres-data-source postgres://user:pass@10.0.32.0/concourse \\
+      --postgres-data-source postgres://user:pass@10.0.32.0/atc \\
       --external-url https://ci.example.com \\
       --peer-url http://10.0.16.10:8080
     }}
@@ -162,7 +162,7 @@ hand or orchestrating it with Docker, Chef, or other ops tooling.
       --session-signing-key session_signing_key \\
       --tsa-host-key tsa_host_key \\
       --tsa-authorized-keys authorized_worker_keys \\
-      --postgres-data-source postgres://user:pass@10.0.32.0/concourse \\
+      --postgres-data-source postgres://user:pass@10.0.32.0/atc \\
       --external-url https://ci.example.com \\
       --peer-url http://10.0.16.11:8080
     }}


### PR DESCRIPTION
This PR attempts to reduce confusion in naming the Postgres database as follows:

At line 100, we say

    This assumes you have a local Postgres server running on the default port
    5432 with an `atc` database, accessible by the current user. If your database
    lives elsewhere, just specify the `--postgres-data-source` flag, which is also
    demonstrated below.

If we look at the "below" part (the subject of this PR), the database is called "concourse",
while above the default value is "atc". This PR always uses the "atc" name.