### PR TITLE
Removed Orange Highlight from the Word 'Tutorial' in Header

### DIFF
--- a/html/page.tmpl
+++ b/html/page.tmpl
@@ -29,7 +29,7 @@
         <h1><a href="/" class="logo"></a><a href="/">Concourse</a></h1>
 
         <nav>
-          <a href="https://concoursetutorial.com" class="tutorial-link">tutorial</a>
+          <a href="https://concoursetutorial.com">tutorial</a>
           <a href="docs.html">docs</a>
           <a href="https://discuss.concourse-ci.org">discuss</a>
           <a href="download.html">download</a>


### PR DESCRIPTION
now it will look like this:
![screen shot 2018-04-23 at 4 17 56 pm](https://user-images.githubusercontent.com/35495560/39150967-edd176f0-4711-11e8-95d6-85a2c653f313.png)
