### PR TITLE
Add ability to specify concourse version in docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse:
-    image: concourse/concourse
+    image: concourse/concourse:${CONCOURSE_VERSION:-latest}
     command: quickstart
     privileged: true
     depends_on: [concourse-db]


### PR DESCRIPTION
This is probably not super useful for most people but I figured I would throw this upstream just in case. 

The reason I added this was because I wanted to match up with an older version of Concourse that we have deployed so that I don't constantly need to `fly sync` when moving between the two environments. Feel free to close out if it doesn't seem like the right place.