### PR TITLE
Fix path of the Community Resources page

### DIFF
--- a/lit/reference/resource-types/community-resources.lit
+++ b/lit/reference/resource-types/community-resources.lit
@@ -198,6 +198,6 @@ before using it!
   Fork the
   \link{\code{concourse/docs}}{https://github.com/concourse/docs}
   repository, edit
-  \code{lit/docs/resource-types/community-resources.lit},
+  \code{lit/reference/resource-types/community-resources.lit},
   then make a pull request.
 }


### PR DESCRIPTION
The file to edit to add a community resource, as displayed in on the community resources page itself, was moved from **lit/docs/...** to **lit/reference/...**

Signed-off-by: Sandrine Piriou <spiriou@pivotal.io>