### PR TITLE
Minor typo in Garbage Collection

### DIFF
--- a/lit/concepts/internals.lit
+++ b/lit/concepts/internals.lit
@@ -542,7 +542,7 @@
       }
 
       Note that if any point of the above process \italic{fails}, the container
-      is left in its current state in the databsae. A container is only ever
+      is left in its current state in the database. A container is only ever
       removed from the database when it's guaranteed that everything has been
       cleaned up.
     }


### PR DESCRIPTION
Currently there is a minor typo in the garbage collection documentation. This corrects that.