### PR TITLE
the emerald-squad is replacing cf-blue-green-resource with cf-zero-do…

### DIFF
--- a/lit/reference/resource-types/community-resources.lit
+++ b/lit/reference/resource-types/community-resources.lit
@@ -179,7 +179,7 @@ before using it!
 }{
   \table-row{\link{Artifactory Resource}{https://github.com/emerald-squad/artifactory-resource}}{by \ghuser{emerald-squad}}
 }{
-  \table-row{\link{CF blue green Resource}{https://github.com/emerald-squad/cf-zero-downtime-resource}}{by \ghuser{emerald-squad}}
+  \table-row{\link{CF Zero Downtime Resource}{https://github.com/emerald-squad/cf-zero-downtime-resource}}{by \ghuser{emerald-squad}}
 }{
   \table-row{\link{FiaaS Resource}{https://github.com/leboncoin/concourse-fiaas-resource}}{by \ghuser{leboncoin}}
 }{

--- a/lit/reference/resource-types/community-resources.lit
+++ b/lit/reference/resource-types/community-resources.lit
@@ -179,7 +179,7 @@ before using it!
 }{
   \table-row{\link{Artifactory Resource}{https://github.com/emerald-squad/artifactory-resource}}{by \ghuser{emerald-squad}}
 }{
-  \table-row{\link{CF blue green Resource}{https://github.com/emerald-squad/cf-blue-green-resource}}{by \ghuser{emerald-squad}}
+  \table-row{\link{CF blue green Resource}{https://github.com/emerald-squad/cf-zero-downtime-resource}}{by \ghuser{emerald-squad}}
 }{
   \table-row{\link{FiaaS Resource}{https://github.com/leboncoin/concourse-fiaas-resource}}{by \ghuser{leboncoin}}
 }{


### PR DESCRIPTION
…wntime-resource

We've deprecated the [cf-blue-green-resource](https://github.com/emerald-squad/cf-blue-green-resource) and replacing it with an alternative that has more features [cf-zero-downtime-resource](https://github.com/emerald-squad/cf-zero-downtime-resource).