### PR TITLE
Docs - Teams - Added note about OAuth application

### DIFF
--- a/lit/setup-and-operations/teams.lit
+++ b/lit/setup-and-operations/teams.lit
@@ -182,6 +182,9 @@ as).
 
       First you need to \link{create an OAuth application on
       GitHub}{https://github.com/settings/applications/new}.
+      If you plan to use OAauth for teams or organization, 
+      you need to create the OAuth application under your
+      organizations settings page - Developer settings -> OAuth Apps.
 
       The name, home page, and description don't matter but should be set to
       something that lets users trust their origin. The \italic{Authorization


### PR DESCRIPTION
I added a much needed note, that if OAuth for Github is going to be used with a organization or team, then the application needs to be created in the organizations settings page.

Fixes this issue completely https://github.com/concourse/concourse/issues/2243

Let me know if any changes are needed!