### PR TITLE
Only show two digits on section headers

### DIFF
--- a/html/section.tmpl
+++ b/html/section.tmpl
@@ -1,7 +1,7 @@
 <div class="section" id="section_{{.PrimaryTag.Name}}">
   {{if .Parent}}
   <h{{headerDepth .}} class="section-header"><a name="{{.PrimaryTag.Name}}"></a>
-    {{- if .Parent -}}
+    {{- if and .Parent (lt .Depth 3) -}}
       <span class="section-number">{{.Number}} </span>
     {{- end -}}
     {{- .Title | render -}}

--- a/html/sidebar.tmpl
+++ b/html/sidebar.tmpl
@@ -22,7 +22,11 @@
         <table>
         {{range .Section.Children}}
           <tr>
-            <td class="number-cell" align="right">{{.Number}}&nbsp;</td>
+            {{if and .Parent (lt .Depth 3)}}
+              <td class="number-cell" align="right">{{.Number}}&nbsp;</td>
+            {{else}}
+              <td class="number-cell" align="left"></td>
+            {{end}}
             <td class="title-cell">{{template "section-link" walkContext $.Current .}}</td>
           </tr>
         {{end}}

--- a/html/toc.tmpl
+++ b/html/toc.tmpl
@@ -2,7 +2,7 @@
 <ol{{if or .SplitSections (not .Parent)}} id="table-of-contents" class="toc"{{end}}>
 {{range .Children}}
   <li>
-    {{- if .Parent -}}
+    {{- if and .Parent (lt .Depth 3) -}}
       <span class="section-number">{{.Number}} </span>
     {{- end -}}
     <a href="{{.PrimaryTag | url}}">{{- .Title | render -}}</a>


### PR DESCRIPTION
Only show two digits on section headers. This change is made across TOC, Sidebar and pages (section). 