### PR TITLE
Add docs for gitlab-auth

### DIFF
--- a/lit/setup-and-operations/install.lit
+++ b/lit/setup-and-operations/install.lit
@@ -192,6 +192,71 @@ page.
   }
 
   \section{
+    \title{GitLab Auth}{gitlab-auth-config}
+
+    A Concourse server can authenticate against GitLab to take advantage of
+    their permission model.
+
+    \section{
+      \title{Creating a GitLab application}
+
+      First you need to \link{create an OAuth application on
+      GitLab}{https://gitlab.com/profile/applications}.
+
+      The redirect URI will be the external URL of your Concourse server with
+      \code{/sky/issuer/callback} appended. For example, Concourse's own CI
+      server's callback URL would be
+      \code{https://ci.concourse-ci.org/sky/issuer/callback}.
+    }
+
+    \section{
+      \title{Configuring the client}
+
+      You will be given a Client ID and a Client Secret for your new
+      application. These will then be passed as the following flags to
+      \code{concourse web}:
+
+      \list{
+        \code{--gitlab-client-id=CLIENT_ID}
+      }{
+        \code{--gitlab-client-secret=CLIENT_SECRET}
+      }
+
+      Here's a full example:
+
+      \codeblock{bash}{{{
+      concourse web \
+        --gitlab-client-id CLIENT_ID \
+        --gitlab-client-secret CLIENT_SECRET
+      }}}
+
+      If you're configuring a self hosted GitLab instance, you'll also need
+      to set the following flag:
+
+      \list{
+        \code{--gitlab-host=https://gitlab.example.com}
+      }
+
+      The GitLab host must contain a scheme and not a trailing slash.
+    }
+
+    \section{
+      \title{Adding GitLab Users to the \code{main} Team}
+
+      Once you have added the GitLab auth connector, you can specify a GitLab
+      Group and/or GitLab User to the
+      \reference{main-team}.
+
+      \codeblock{bash}{{{
+        concourse web \
+          ... \
+          --main-team-gitlab-group=GROUP_NAME \
+          --main-team-gitlab-user=USERNAME
+      }}}
+    }
+  }
+
+  \section{
     \title{CF Auth}{cf-auth-config}
 
     Cloud Foundry (CF) Auth can be used for operators who wish to authenticate

--- a/lit/setup-and-operations/teams.lit
+++ b/lit/setup-and-operations/teams.lit
@@ -193,6 +193,33 @@ against the teams that have granted them access.
     }}}
   }
 
+    \section{
+    \title{GitLab Auth}{gitlab-auth}
+
+    You can configure which groups and individual users
+    should have access to your team.
+
+    This is done by passing the following flags:
+
+    \definitions{
+      \definition{\code{--gitlab-user=USERNAME}}{
+        Authorize an individual user.
+      }
+    }{
+      \definition{\code{--gitlab-group=GROUP_NAME}}{
+        Authorize an entire groups's members.
+      }
+    }
+
+    For example:
+
+    \codeblock{bash}{{{
+    $ fly set-team -n my-team \
+        --gitlab-user my-gitlab-user \
+        --gitlab-team my-team
+    }}}
+  }
+
   \section{
     \title{CF Auth}{uaa-cf-auth}
 


### PR DESCRIPTION
As requested in https://github.com/concourse/concourse/issues/1701 I added a section for GitLab auth in to the docs for the installation and the fly cli.