### PR TITLE
Fix github-pr-resource credit to telia-oss

### DIFF
--- a/lit/reference/resource-types/community-resources.lit
+++ b/lit/reference/resource-types/community-resources.lit
@@ -19,7 +19,7 @@ before using it!
 }{
   \table-row{\link{Slack notifications}{https://github.com/cloudfoundry-community/slack-notification-resource}}{by \ghuser{cloudfoundry-community}}
 }{
-  \table-row{\link{Github Pull Requests}{https://github.com/telia-oss/github-pr-resource}}{by \ghuser{itsdalmo}}
+  \table-row{\link{Github Pull Requests}{https://github.com/telia-oss/github-pr-resource}}{by \ghuser{telia-oss}}
 }{
   \table-row{\link{GitLab Merge Requests}{https://github.com/swisscom/gitlab-merge-request-resource}}{by \ghuser{swisscom}}
 }{


### PR DESCRIPTION
Just noticed that the Github Pull Requests community resource has been attributed to me and not https://github.com/telia-oss - this is a PR to fix that 😄 