### PR TITLE
Add Github Webhook Resource

### DIFF
--- a/lit/reference/resource-types/community-resources.lit
+++ b/lit/reference/resource-types/community-resources.lit
@@ -218,6 +218,8 @@ before using it!
   \table-row{\link{Gate Resource}{https://github.com/Meshcloud/gate-resource}}{by \ghuser{Meshcloud}}
 }{
   \table-row{\link{Packer}{https://github.com/Snapkitchen/concourse-packer-resource}}{by \ghuser{Snapkitchen}}
+}{
+  \table-row{\link{Github Webhook Resource}{https://github.com/homedepot/github-webhook-resource}}{by \ghuser{homedepot}}
 }
 
 \section{


### PR DESCRIPTION
Adds a link to https://github.com/homedepot/github-webhook-resource