### PR TITLE
document quickstart's need for sudo

### DIFF
--- a/lit/setup-and-operations/install.lit
+++ b/lit/setup-and-operations/install.lit
@@ -50,6 +50,11 @@ page.
     --worker-work-dir /opt/concourse/worker
   }}}
 
+  \italic{
+    Note: on Linux and OSX, you'll need to run this as root or using
+    \code{sudo} because the \reference{worker-node} needs elevated privileges.
+  }
+
   This command is shorthand for running a single \reference{web-node} and
   \reference{worker-node} on the same machine, auto-wired to trust each other.
   We've also configured some local auth for the \reference{main-team} -


### PR DESCRIPTION
Adds a note to the Quickstart explaining why we might need sudo.

Resolves https://github.com/concourse/concourse/issues/3065