### PR TITLE
docs(creds): Adds documentation for Azure Key Vault credential provider

### DIFF
--- a/lit/setup-and-operations/operation/creds.lit
+++ b/lit/setup-and-operations/operation/creds.lit
@@ -11,8 +11,9 @@ external to the pipeline or team, and prevents them from being revealed by
 Currently, the only supported credential managers are
 \link{Vault}{https://vaultproject.io},
 \link{Credhub}{https://github.com/cloudfoundry-incubator/credhub},
-\link{Amazon SSM}{https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html}, and
-\link{Amazon Secrets Manager}{https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html}.
+\link{Amazon SSM}{https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html},
+\link{Amazon Secrets Manager}{https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html}, and
+\link{Azure Key Vault}{https://docs.microsoft.com/en-us/azure/key-vault/}.
 
 Credential management works by replacing the credentials with
 \reference{pipeline-params} in your pipeline or task config. When the ATC is
@@ -600,5 +601,100 @@ values are not present, the action will error.
     The leading \code{/concourse} can be changed by specifying
     \code{--aws-secretsmanager-pipeline-secret-template} or
     \code{--aws-secretsmanager-team-secret-template} variables.
+  }
+}
+
+\section{
+  \title{Using Key Vault}{keyvault}
+
+  \omit-children-from-table-of-contents
+
+  \section{
+    \title{Configuration}
+
+    The ATC is statically configured with a Key Vault URL, service principal ID,
+    service principal secret/key, and a tenant ID. The specified service
+    principal needs to have Get and List access for secrets in the Key Vault.
+
+    The following configuration is defined:
+
+    \define-attribute{keyvault-url: string}{
+      The URL of the Key Vault to use.
+
+      Environment variable \code{CONCOURSE_KEYVAULT_KEY_VAULT_URL}.
+    }
+
+    \define-attribute{keyvault-service-principal-id: string}{
+      Azure service principal ID. It should have read and list access to the Key
+      Vault you are trying to access.
+
+      Environment variable \code{CONCOURSE_KEYVAULT_SERVICE_PRINCIPAL_ID}.
+    }
+
+    \define-attribute{keyvault-service-principal-key: string}{
+      Azure service principle key or password.
+
+      Environment variable \code{CONCOURSE_KEYVAULT_SERVICE_PRINCIPAL_KEY}.
+    }
+
+    \define-attribute{keyvault-tenant-id: string}{
+      The ID of the Azure AD tenant the service principal is part of.
+
+      Environment variable \code{CONCOURSE_KEYVAULT_TENANT_ID}.
+    }
+
+    \define-attribute{keyvault-key-prefix: string}{
+      Value under which to prefix key names.
+
+      Environment variable \code{CONCOURSE_KEYVAULT_KEY_PREFIX}.
+
+      Default: \code{concourse}.
+    }
+
+    \define-attribute{keyvault-environment: string}{
+      The Azure environment to use, especially if you don't use the public
+      cloud. If you need to change this from the default, you'll know it.
+
+      Environment variable \code{CONCOURSE_KEYVAULT_ENVIRONMENT}.
+
+      Default: \code{AzurePublicCloud}.
+    }
+
+    For example, to point the ATC at a Key Vault you can configure:
+
+    \codeblock{bash}{{{
+      concourse web ... \
+        --keyvault-key-vault-url https://foo.vault.azure.net \
+        --keyvault-service-principal-id da02fe05-aa49-4865-059b-67ab1c5c2f63 \
+        --keyvault-service-principal-key da02fe05-fa39-4865-059b-67221c1d2f23 \
+        --keyvault-tenant-id 6a174c20-f6de-a53c-74d2-6018fcceff64
+
+      # or use env variables
+      CONCOURSE_KEYVAULT_KEY_VAULT_URL="https://foo.vault.azure.net" \
+      CONCOURSE_KEYVAULT_SERVICE_PRINCIPAL_ID="da02fe05-aa49-4865-059b-67ab1c5c2f63 " \
+      CONCOURSE_KEYVAULT_SERVICE_PRINCIPAL_KEY="da02fe05-fa39-4865-059b-67221c1d2f23" \
+      CONCOURSE_KEYVAULT_TENANT_ID="6a174c20-f6de-a53c-74d2-6018fcceff64" \
+      concourse web ...
+    }}}
+  }
+
+  \section{
+    \title{Credential Lookup Rules}
+
+    Because Key Vault does not use paths or have nesting, all secrets have "-" delimited "paths." When resolving a parameter such as \code{((foo_param))}, it will look for
+    the following secret names, in order:
+
+    \list{
+      \code{
+        concourse-TEAM_NAME-PIPELINE_NAME-foo_param
+      }
+    }{
+      \code{
+        concourse-TEAM_NAME-foo_param
+      }
+    }
+
+    The leading \code{concourse} can be changed by specifying
+    \code{--keyvault-key-prefix}.
   }
 }


### PR DESCRIPTION
This is dependent on the [associated PR in Concourse](https://github.com/concourse/concourse/pull/3081) being merged