### PR TITLE
update documentation for SSM IAM policy

### DIFF
--- a/lit/setup-and-operations/operation/creds.lit
+++ b/lit/setup-and-operations/operation/creds.lit
@@ -405,7 +405,10 @@ values are not present, the action will error.
               {
                   "Sid": "AllowAccessToSsmParameters",
                   "Effect": "Allow",
-                  "Action": "ssm:GetParameters",
+                  "Action": [
+                      "ssm:GetParameter",
+                      "ssm:GetParametersByPath"
+                      ],
                   "Resource": [
                       "arn:aws:ssm:::parameter/concourse/*",
                       "arn:aws:ssm:::parameter/concourse/TEAM_NAME/*",


### PR DESCRIPTION
The previous documentation for an IAM role policy for SSM suggested that you need `"Action": "ssm:GetParameters"` (plural), but from what I can tell in the code, you actually need [GetParameter](https://github.com/concourse/atc/blob/master/creds/ssm/ssm.go#L89) (singular) and probably also [GetParametersByPath](https://github.com/concourse/atc/blob/master/creds/ssm/ssm.go#L110).

Using SSM with only `GetParameters`, as described in the documentation, results in:
```
AccessDeniedException: User: arn:aws:sts::1234567890:assumed-role/concourse-server/i-004a9db0f17a99056 is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:us-east-1:1234567890:parameter/concourse/main/foo
```