### PR TITLE
replace deprecated Azure Blobstore resource with an actively maintain…

### DIFF
--- a/lit/docs/resource-types/community-resources.lit
+++ b/lit/docs/resource-types/community-resources.lit
@@ -87,7 +87,7 @@ before using it!
 }{
   \table-row{\link{bbl (BOSH Bootloader) state}{https://github.com/cloudfoundry/bbl-state-resource}}{by \ghuser{cloudfoundry}}
 }{
-  \table-row{\link{Azure Blobstore}{https://github.com/pivotal-cloudops/azure-blobstore-concourse-resource}}{by \ghuser{pivotal-cloudops}}
+  \table-row{\link{Azure Blobstore}{https://github.com/pivotal-cf/azure-blobstore-resource}}{by \ghuser{pivotal-cf}}
 }{
   \table-row{\link{Rsync}{https://github.com/mrsixw/concourse-rsync-resource}}{by \ghuser{mrsixw}}
 }{


### PR DESCRIPTION
…ed one

The previously listed Azure Blobstore resource is not actively maintained, and the resource repo provides no suggestions of replacements to consider. I've updated the community resources page to point to an actively maintained (by @pivotal-cf) resource.