### PR TITLE
Concourse 5 allows overlapping paths

### DIFF
--- a/lit/docs/tasks.lit
+++ b/lit/docs/tasks.lit
@@ -131,7 +131,7 @@ A task's configuration specifies the following:
 
     Paths are relative to the working directory of the task. Absolute paths are not respected.
 
-    Note that this value \italic{must not overlap} with any other inputs or
+    Note that this value \italic{must not overlap} with any other
     outputs. Each output results in a new empty directory that your task
     should place artifacts in; if the path overlaps it'll clobber whatever
     files used to be there.


### PR DESCRIPTION
If I understood https://concourse-ci.org/download.html#v500-note-16 correctly, we can now have overlapping inputs and outputs.
Thus I suggest to change the wording here (or at least explain that it is now allowed in some cases).
Please feel free to rewrite my proposal if you find better wording.