### PR TITLE
Revert "Correct link to `CONTRIBUTING.md`"

### DIFF
--- a/lit/contribute.lit
+++ b/lit/contribute.lit
@@ -43,7 +43,7 @@ in contributing to Concourse's development:
   and making PRs against the project.
 }{
   \bold{Contributing Code}. If you're interested in contributing some work to
-  the core project, you can get started by reviewing the \link{\code{CONTRIBUTING.md}}{https://github.com/concourse/concourse/blob/master/.github/CONTRIBUTING.md}
+  the core project, you can get started by reviewing the \link{\code{CONTRIBUTING.md}}{https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md}
   getting started guide. You can also get an overview of the Concourse architecture
   by reviewing some of the documentation under \link{Concourse Architecture}{architecture.html}.
   If you're curious about what we're working on you can follow along with the team's


### PR DESCRIPTION
This reverts commit 790423c6f77b3fc9fbefeee93a417de458ebe0a9, as it now
gives a 404 as the the CONTRIBUTING.md is once again in the root of the
main `concourse` repo.

(Force pushed to include "Signed-off-by". :flushed:)