### PR TITLE
Add documentation for in_parallel step

### DIFF
--- a/lit/docs/jobs/steps.lit
+++ b/lit/docs/jobs/steps.lit
@@ -22,6 +22,7 @@ appear as outputs.
 \include-section{./steps/put.lit}
 \include-section{./steps/task.lit}
 \include-section{./steps/aggregate.lit}
+\include-section{./steps/in_parallel.lit}
 \include-section{./steps/do.lit}
 \include-section{./steps/try.lit}
 \include-section{./steps/on_success.lit}

--- a/lit/docs/jobs/steps/aggregate.lit
+++ b/lit/docs/jobs/steps/aggregate.lit
@@ -2,6 +2,8 @@
 
 \title{\code{aggregate} step}{aggregate-step}
 
+\italic{aggregate} is deprecated and will be removed in a future version. Please see \reference{in-parallel-step}{\code{in_parallel}} instead.
+
 \define-attribute{aggregate: [step]}{
   Performs the given steps in parallel.
 

--- a/lit/docs/jobs/steps/in_parallel.lit
+++ b/lit/docs/jobs/steps/in_parallel.lit
@@ -1,0 +1,86 @@
+\use-plugin{concourse-docs}
+
+\title{\code{in_parallel} step}{in-parallel-step}
+
+\define-attribute{in_parallel: [step]}{
+  Performs the given steps in parallel.
+
+  If any sub-steps (or \reference{task-step}{\code{task}}) in a \code{parallel}
+  result in a failure or error, the parallel step as a whole is considered to have 
+  failed or errored.
+}
+
+\define-attribute{steps: [step]}{
+  \italic{Optional.} The steps to perform in parallel.
+}{steps}
+
+\define-attribute{limit: integer}{
+  \italic{Optional. Default is no limit.} A sempahore which limits the
+  parallelism when executing the steps in a \code{in_parallel} step. When set,
+  the number of running steps will not exceed the limit. 
+
+  When not specified \code{in_parallel} will execute all steps immediately,
+  making the default behavior identical to \reference{aggregate-step}{\code{aggregate}}.
+}{limit}
+
+\define-attribute{fail_fast: bool}{
+  \italic{Optional. Default is \code{false}.} When enabled the parallel step will
+  fail fast by returning as soon as any sub-step fails. This means that running steps
+  will be interrupted and pending steps will no longer be scheduled.
+}{fail-fast}
+
+\right-side{Examples}{
+  \example{Build Matrix}{
+    If any step in the \code{in_parallel} fails, the build will fail, making it
+    useful for build matrices:
+
+    \codeblock{yaml}{{
+    plan:
+    - get: some-repo
+    - in_parallel:
+      - task: unit-windows
+        file: some-repo/ci/windows.yml
+      - task: unit-linux
+        file: some-repo/ci/linux.yml
+      - task: unit-darwin
+        file: some-repo/ci/darwin.yml
+    }}
+  }
+
+  \example{Parallel Fetching}{
+    The \code{in_parallel} step is useful for speeding up builds, and is often used to fetch
+    all dependent resources together:
+
+    \codeblock{yaml}{{
+    plan:
+    - in_parallel:
+      - get: component-a
+      - get: component-b
+      - get: integration-suite
+    - task: integration
+      file: integration-suite/task.yml
+    }}
+  }
+  
+  \example{Limited Parallelism}{
+    Using \code{limit} is useful for performing parallel execution of
+    a growing number of tasks without overloading your workers. In the example 
+    below, two tasks will be run in parallel and in order until all steps have 
+    been executed:
+
+    \codeblock{yaml}{{
+    plan:
+    - get: some-repo
+    - in_parallel:
+      limit: 2
+      fail_fast: false
+      steps:
+        - task: unit-windows
+          file: some-repo/ci/windows.yml
+        - task: unit-linux
+          file: some-repo/ci/linux.yml
+        - task: unit-darwin
+          file: some-repo/ci/darwin.yml
+    }}
+  }
+}

--- a/lit/docs/jobs/steps/task.lit
+++ b/lit/docs/jobs/steps/task.lit
@@ -31,15 +31,15 @@ of a task.
     }}
   }
 
-  \example{Build Matrix with \code{aggregate}}{
+  \example{Build Matrix with \code{in_parallel}}{
     The following plan fetches a single repository and executes multiple tasks,
-    using the \reference{aggregate-step}{\code{aggregate}} step, in a build matrix
+    using the \reference{in-parallel-step}{\code{in_parallel}} step, in a build matrix
     style configuration:
 
     \codeblock{yaml}{{
     plan:
     - get: my-repo
-    - aggregate:
+    - in_parallel:
       - task: go-1.3
         file: my-repo/go-1.3.yml
       - task: go-1.4
@@ -47,7 +47,7 @@ of a task.
     }}
 
     Only if both tasks succeed will the build go green. See also
-    \reference{aggregate-step}.
+    \reference{in-parallel-step}.
   }
 }
 


### PR DESCRIPTION
This PR adds documentation for a `parallel` step: https://github.com/concourse/concourse/pull/3580
