### PR TITLE
Update aws secretsmanager doc

### DIFF
--- a/lit/docs/operation/creds/aws-secretsmanager.lit
+++ b/lit/docs/operation/creds/aws-secretsmanager.lit
@@ -34,7 +34,7 @@
   \define-attribute{aws-secretsmanager-region: string}{
     The AWS region that requests to Secrets Manager will be sent to.
 
-    Environment variable \code{AWS_REGION}.
+    Environment variable \code{CONCOURSE_AWS_SECRETSMANAGER_REGION}.
   }
 
   \define-attribute{aws-secretsmanager-pipeline-secret-template: string}{
@@ -67,7 +67,7 @@
       --aws-secretsmanager-secret-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
     # or use env variables
-    AWS_REGION="us-east-1" \
+    CONCOURSE_AWS_SECRETSMANAGER_REGION="us-east-1" \
     CONCOURSE_AWS_SECRETSMANAGER_ACCESS_KEY="AKIAIOSFODNN7EXAMPLE" \
     CONCOURSE_AWS_SECRETSMANAGER_SECRET_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
     concourse web ...


### PR DESCRIPTION
Reflect the current implementation for AWS_REGION env var for aws secretsmanager.
The ENV var AWS_REGION was removed in: https://github.com/concourse/concourse/issues/2191