### PR TITLE
Fixes the hover state color for header links

### DIFF
--- a/css/booklit.css
+++ b/css/booklit.css
@@ -249,6 +249,7 @@ h3 {
   text-decoration: none;
 }
 .top-link:hover {
+  color: white;
   text-decoration: underline;
 }
 .top-link.active {


### PR DESCRIPTION
Links were disappearing on Safari. 

![concourse-docs-links](https://user-images.githubusercontent.com/347097/57027574-c1e51780-6c0a-11e9-8cb1-5912ddc02d4f.gif)

![giphy (22)](https://user-images.githubusercontent.com/347097/57027851-84cd5500-6c0b-11e9-9679-1eb79eed76c7.gif)
