### PR TITLE
in master, quickstart will not start without specifying worker work-dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,4 @@ services:
       CONCOURSE_EXTERNAL_URL: http://localhost:8080
       CONCOURSE_ADD_LOCAL_USER: test:test
       CONCOURSE_MAIN_TEAM_LOCAL_USER: test
+      CONCOURSE_WORKER_WORK_DIR: /tmp


### PR DESCRIPTION
Quickstart will not start unless worker's work-dir is specified. This is for the code currently in master branch. The released code will not start due to non-specified TLS options. 