### PR TITLE
Update roles.lit to reflect five roles.

### DIFF
--- a/lit/docs/auth/roles.lit
+++ b/lit/docs/auth/roles.lit
@@ -2,8 +2,7 @@
 
 \use-plugin{concourse-docs}
 
-Concourse comes with four roles: Concourse Admin, Team Owner, Team Member,
-Team Viewer.
+Concourse comes with five roles: Concourse Admin, Team Owner, Team Member, Pipeline Operator, Team Viewer.
 
 \section{
   \title{Concourse Admin}{concourse-admin}


### PR DESCRIPTION
Seems like we have five roles, not four. Updated to include Pipeline Operator. 