### PR TITLE
Unbreak quickstart

### DIFF
--- a/lit/index.lit
+++ b/lit/index.lit
@@ -30,7 +30,7 @@
   target your local Concourse as the \code{test} user:
 
   \codeblock{bash}{{
-  $ fly -t tutorial login -c http://localhost:8080
+  $ fly -t tutorial login -c http://localhost:8080 -u test -p test
   logging in to team 'main'
 
   target saved


### PR DESCRIPTION
Actually make the `fly login` successful by passing the credentials.

If ones follows the quickstart, what he gets is:

```
fly -t ci login -c http://localhost:8080
logging in to team 'main'

navigate to the following URL in your browser:

  http://localhost:8080/login?fly_port=62558

or enter token manually: ^C
```

while the quickstart shows:

```
fly -t tutorial login -c http://localhost:8080
logging in to team 'main'

target saved
```



Note: there are two options to actually have a quickstart that works:
1. this PR
2. or, keep the usage of `fly login` as is, and change the text around it to explain that you have to login into the web UI.

This also somehow fixes #97