### PR TITLE
Update docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
   concourse:
     image: concourse/concourse
     command: quickstart
-    privileged: true
     depends_on: [concourse-db]
     ports: ["8080:8080"]
     environment:
@@ -23,3 +22,4 @@ services:
       CONCOURSE_EXTERNAL_URL: http://localhost:8080
       CONCOURSE_ADD_LOCAL_USER: test:test
       CONCOURSE_MAIN_TEAM_LOCAL_USER: test
+      CONCOURSE_WORKER_BAGGAGECLAIM_DRIVER: overlay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
   concourse:
     image: concourse/concourse
     command: quickstart
+    privileged: true
     depends_on: [concourse-db]
     ports: ["8080:8080"]
     environment:

--- a/latest-rc.override.yml
+++ b/latest-rc.override.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+services:
+  concourse:
+    image: concourse/concourse-rc:latest


### PR DESCRIPTION
This PR does two things.

1. Updated the docker-compose file to use overlay. We do the same thing in the main concourse repo. Makes it easier for us to test `quickstart` in ci. https://github.com/concourse/concourse/blob/48b9eacc570dcec6713b7272b1d6597bcd21d188/docker-compose.yml#L47-L48
2. Adds a docker-compose override file that changes the concourse image to `concourse/concourse-rc:latest`. This makes it easier for us to test the `quickstart` command against the latest rc image.

Note: to use the override file, run: 
`docker-compose -f docker-compose.yml -f latest-rc.override.yml up` 

CC @zoetian 