### PR TITLE
Update PHP example composer-setup.php sha384 value.

### DIFF
--- a/lit/examples/php.lit
+++ b/lit/examples/php.lit
@@ -41,7 +41,7 @@ jobs:
                 apt-get install -y git unzip
 
                 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-                php -r "if (hash_file('sha384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+                php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
                 php composer-setup.php --filename=composer --install-dir=/usr/bin
                 php -r "unlink('composer-setup.php');"
 


### PR DESCRIPTION
Going through the PHP example, I noticed a failure similar to what was seen in the Concourse CI. This updates the SHA384 value and fixes the issue.