### PR TITLE
Fix reference

### DIFF
--- a/lit/docs/jobs/steps/put.lit
+++ b/lit/docs/jobs/steps/put.lit
@@ -57,7 +57,7 @@ available under whatever name \code{put} specifies, just like as with
 }{put-step-put}
 
 \define-attribute{resource: string}{
-  \italic{Optional. Defaults to \code{name}.} The resource to update, as
+  \italic{Optional. Defaults to the value of \code{put}.} The resource to update, as
   configured in \reference{pipeline-resources}.
 }{put-step-resource}
 


### PR DESCRIPTION
In the original description, a non-existent variable `name` was being referenced in the description of the `resource` definition. This PR fixes that description and correctly references `put`.