### PR TITLE
Add target example to managing teams docs

### DIFF
--- a/lit/docs/auth/managing-teams.lit
+++ b/lit/docs/auth/managing-teams.lit
@@ -27,7 +27,7 @@
   Once the team has been created, you can use \reference{fly-login} to log in:
 
   \codeblock{bash}{{
-  $ fly login -n my-team
+  $ fly -t example login -n my-team
   }}
 
   Any newly configured pipelines (via \reference{fly-set-pipeline}) and one-off


### PR DESCRIPTION
Small fix to the documentation. When logging into a team you still need to set the target.