### PR TITLE
Fixed flag documentation for set-team config

### DIFF
--- a/lit/docs/auth/managing-teams.lit
+++ b/lit/docs/auth/managing-teams.lit
@@ -47,7 +47,7 @@
     \reference{team-member-role}.
 
     More advanced \reference{user-roles}{roles} configuration can be specified
-    through the \code{--configuration} or \code{-c} flag.
+    through the \code{--config} or \code{-c} flag.
 
     The \code{-c} flag expects a \code{.yml} file with a single field,
     \code{roles:}, pointing to a list of role authorization configs.


### PR DESCRIPTION
Simple update to fix documentation on passing configuration to set-team
https://github.com/concourse/concourse/blob/master/skymarshal/skycmd/flags.go#L55