### PR TITLE
differentiate the 'bad' step hooks

### DIFF
--- a/lit/docs/jobs/steps/on_abort.lit
+++ b/lit/docs/jobs/steps/on_abort.lit
@@ -3,7 +3,8 @@
 \title{\code{on_abort} step hook}{on-abort-step-hook}
 
 Any step can have \code{on_abort} tacked onto it, whose value is a second
-step to execute only if the parent step aborts.
+step to execute only if the parent step is aborted, via clicking the X in the
+web UI or by running \reference{fly-abort-build}.
 
 \define-attribute{on_abort: step}{
   The step to execute when the parent step aborts. If the attached step

--- a/lit/docs/jobs/steps/on_error.lit
+++ b/lit/docs/jobs/steps/on_error.lit
@@ -3,7 +3,11 @@
 \title{\code{on_error} step hook}{on-error-step-hook}
 
 Any step can have \code{on_error} tacked onto it, whose value is a second step
-to execute only if the parent step errors.
+to execute only if the parent step terminates abnormally in any way other than
+those handled by the \reference{on-abort-step-hook} or
+\reference{on-failure-step-hook} -- this covers scenarios as broad as
+configuration mistakes, temporary network issues or running longer than a
+\reference{timeout-step-modifier}.
 
 \define-attribute{on_error: step}{
   The step to execute when the parent step errors. If the attached step

--- a/lit/docs/jobs/steps/on_failure.lit
+++ b/lit/docs/jobs/steps/on_failure.lit
@@ -3,7 +3,11 @@
 \title{\code{on_failure} step hook}{on-failure-step-hook}
 
 Any step can have \code{on_failure} tacked onto it, whose value is a second
-step to execute only if the parent step fails.
+step to execute only if the parent step completes its execution, but its process
+(the script specified via \reference{task-run} in the case of a
+\reference{task-step}, or the \reference{resource-in} script for a
+\reference{get-step}, or the \reference{resource-out} script for a
+\reference{put-step}) exits with a non-zero status code.
 
 \define-attribute{on_failure: step}{
   The step to execute when the parent step fails. If the attached step

--- a/lit/docs/resource-types/implementing.lit
+++ b/lit/docs/resource-types/implementing.lit
@@ -96,7 +96,7 @@ UI, so you should make your output pretty.
 }
 
 \section{
-  \title{\code{in}\aux{: Fetch a given resource.}}
+  \title{\code{in}\aux{: Fetch a given resource.}}{resource-in}
 
   The \code{in} script is passed a destination directory as command line argument \code{$1}, and
   is given on stdin the configured source and a precise version of the resource
@@ -159,7 +159,7 @@ UI, so you should make your output pretty.
 }
 
 \section{
-  \title{\code{out}\aux{: Update a resource.}}
+  \title{\code{out}\aux{: Update a resource.}}{resource-out}
 
   The \code{out} script is called with a path to the directory containing the
   build's full set of sources as the first argument, and is given on stdin the


### PR DESCRIPTION
Fixes concourse/docs#267.

I have tried to make these descriptions helpful and specific without being misleading. We could probably do a bit better giving users a sense of how build execution works overall, but I think this is a step in the right direction.