### PR TITLE
docs: add tracing section

### DIFF
--- a/lit/docs/operation.lit
+++ b/lit/docs/operation.lit
@@ -11,6 +11,7 @@ them, but we do recommend at least learning how to set up \reference{creds} and
 \include-section{./operation/encryption.lit}
 \include-section{./operation/creds.lit}
 \include-section{./operation/metrics.lit}
+\include-section{./operation/tracing.lit}
 \include-section{./operation/container-placement.lit}
 \include-section{./operation/global-resources.lit}
 \include-section{./operation/administration.lit}

--- a/lit/docs/operation/tracing.lit
+++ b/lit/docs/operation/tracing.lit
@@ -20,6 +20,11 @@ other systems is planned to expand as the underlying SDK
   There's only one variable that is required to be set in order to leverage
   Jaeger's integration with Concourse: \code{CONCOURSE_TRACING_JAEGER_ENDPOINT}.
 
+
+  \codeblock{bash}{{{
+  CONCOURSE_TRACING_JAEGER_ENDPOINT=http://jaeger:14268/api/traces
+  }}}
+
   This tells Concourse how to target Jaeger's Thrift HTTP endpoint to send the
   traces to.
 }

--- a/lit/docs/operation/tracing.lit
+++ b/lit/docs/operation/tracing.lit
@@ -1,0 +1,25 @@
+\title{Tracing}{tracing}
+
+\use-plugin{concourse-docs}
+
+\warn{This is an \bold{experimental} feature.}
+
+Tracing in Concourse enables the delivery of traces related to the internal
+processes that go into running builds, and other internal operations, breaking
+them down by time, and component.
+
+It currently only integrates with
+\link{\italic{Jaeger}}{https://www.jaegertracing.io/}, although support for
+other systems is planned to expand as the underlying SDK
+(\link{\italic{OpenTelemetry}}{https://opentelemetry.io/}) evolves.
+
+
+\section{
+  \title{Configuring}
+
+  There's only one variable that is required to be set in order to leverage
+  Jaeger's integration with Concourse: \code{CONCOURSE_TRACING_JAEGER_ENDPOINT}.
+
+  This tells Concourse how to target Jaeger's Thrift HTTP endpoint to send the
+  traces to.
+}


### PR DESCRIPTION
Hey,

This PR adds a minimal documentation for concourse/concourse#4607

<img width="578" alt="Screen Shot 2019-11-12 at 8 37 47 AM" src="https://user-images.githubusercontent.com/3574444/68676368-e447de00-0527-11ea-9ca7-993bb530cac9.png">


<details>
<summary>
see previous rendered version
</summary>
<img width="609" alt="Screen Shot 2019-11-11 at 12 15 50 PM" src="https://user-images.githubusercontent.com/3574444/68606757-194b2680-047d-11ea-95aa-7a22125d783a.png">
</details>

wdyt?

thanks!