### PR TITLE
fix typo

### DIFF
--- a/lit/docs.lit
+++ b/lit/docs.lit
@@ -24,7 +24,7 @@ interval triggers, via the \resource{time}.
 the pipelines more self-contained and keeping Concourse itself small and
 generic without resorting to a complicated plugin system.
 
-\reference{jobs} are sequences \reference{get-step}{\code{get}},
+\reference{jobs} are sequences of \reference{get-step}{\code{get}},
 \reference{put-step}{\code{put}}, and \reference{task-step}{\code{task}} steps
 to execute. These \reference{steps}{steps} determine the job's inputs and
 outputs. Jobs are designed to be idempotent and loosely coupled, allowing the

--- a/lit/docs/install.lit
+++ b/lit/docs/install.lit
@@ -45,7 +45,7 @@ flag is based on the flag name, preceded with \code{CONCOURSE_}. These are
 also shown in \code{--help}.
 
 Various sections in documentation may refer to configuration via env vars
-rather than flags, but they are both equivalent an interchangeable. Env
+rather than flags, but they are both equivalent and interchangeable. Env
 vars are just easier to reference in isolation and are more useful to
 copy-paste.
 

--- a/lit/docs/install/web.lit
+++ b/lit/docs/install/web.lit
@@ -195,7 +195,7 @@ as performing all pipeline scheduling. It's basically the brain of Concourse.
 
     The \code{web} nodes can be killed and restarted willy-nilly. No draining
     is necessary; if the \code{web} node was orchestrating a build it will just
-    continue where it left off when it comes back or, or the build will be
+    continue where it left off when it comes back, or the build will be
     picked up by one of the other \code{web} nodes.
 
     To upgrade a \code{web} node, stop its process and start a new one using


### PR DESCRIPTION
maybe it was supposed to be "*sequenced* get, put, and task steps" rather than "*sequences of* get, put, and task steps", but either way just saying "sequences get, put, and task steps" seems like a typo.

lmk if y'all even want tiny PRs like this in the future or if they aren't worth your time :)