### PR TITLE
add docs for fly enable and disable-resource-version

### DIFF
--- a/lit/docs/auth/roles.lit
+++ b/lit/docs/auth/roles.lit
@@ -251,8 +251,8 @@ and viewers cannot.
     \table-row{CreateJobBuild               }{\reference{fly-trigger-job}                                       }{trigger button on job and build pages  }{✘                                }{✓           }
     \table-row{CreatePipelineBuild          }{\reference{fly-execute}                                           }{n/a                                    }{✘                                }{✓           }
     \table-row{DeletePipeline               }{\reference{fly-destroy-pipeline}                                  }{n/a                                    }{✘                                }{✓           }
-    \table-row{DisableResourceVersion       }{n/a                                                               }{version disable widget on resource page}{✘                                }{✓           }
-    \table-row{EnableResourceVersion        }{n/a                                                               }{version enable widget on resource page }{✘                                }{✓           }
+    \table-row{DisableResourceVersion       }{\reference{fly-disable-resource-version}                          }{version disable widget on resource page}{✘                                }{✓           }
+    \table-row{EnableResourceVersion        }{\reference{fly-enable-resource-version}                           }{version enable widget on resource page }{✘                                }{✓           }
     \table-row{PinResourceVersion           }{\reference{fly-pin-resource}                                      }{pin buttons on resource page           }{✘                                }{✓           }
     \table-row{UnpinResource                }{\code{fly unpin-resource}                                         }{pin buttons on resource page           }{✘                                }{✓           }
     \table-row{SetPinCommentOnResource      }{\reference{fly-pin-resource}                                      }{comment overlay on resource page       }{✘                                }{✓           }

--- a/lit/docs/resources/managing.lit
+++ b/lit/docs/resources/managing.lit
@@ -67,3 +67,44 @@
   the resource page. A default comment is automatically
   generated containing your username and a timestamp. This comment can be edited.
 }
+
+\section{
+  \title{\code{fly enable-resource-version}}{fly-enable-resource-version}
+
+  To enable a specific version of a resource, run:
+
+  \codeblock{bash}{{{
+  $ fly -t example enable-resource-version --resource my-pipeline/my-resource \
+      --version ref:bceaf
+  }}}
+
+  Note that the version needs to be provided as a key-value pair. For the git
+  resource the \code{ref:} prefix is used while the \italic{registry} 
+  resource might use \code{digest} as a prefix like \code{digest:sha256:94be7d7b}.
+
+  This command is idempotent. Enabling an already enabled resource version will do nothing.
+
+  You can also enable a resource version via the UI by clicking on the check mark button next to the desired version on
+  the resource page.
+}
+
+\section{
+  \title{\code{fly disable-resource-version}}{fly-disable-resource-version}
+
+  To disable a specific version of a resource, run:
+
+  \codeblock{bash}{{{
+  $ fly -t example disable-resource-version --resource my-pipeline/my-resource \
+      --version ref:bceaf
+  }}}
+
+  Note that the version needs to be provided as a key-value pair. For the git
+  resource the \code{ref:} prefix is used while the \italic{registry} 
+  resource might use \code{digest} as a prefix like \code{digest:sha256:94be7d7b}.
+
+  This command is idempotent. Disabling an already disabled resource version will do nothing.
+
+  You can also disable a resource version via the UI by clicking on the check mark button next to the desired version on
+  the resource page.
+}
+


### PR DESCRIPTION
This commit adds the docs for https://github.com/concourse/concourse/pull/4876.
