### PR TITLE
update AWS secrets manager description

### DIFF
--- a/lit/docs/auth/roles.lit
+++ b/lit/docs/auth/roles.lit
@@ -38,6 +38,17 @@ and viewers cannot.
 
   Admins always have permission to perform any action on any team. You cannot
   assign actions to the admin role using the \code{--config-rbac} flag.
+
+  The following actions are also assigned to admins, and cannot be reconfigured:
+
+  \codeblock{yaml}{{{
+  - GetLogLevel
+  - ListActiveUsersSince
+  - SetLogLevel
+  - GetInfoCreds
+  - SetWall
+  - ClearWall
+  }}}
 }
 
 \section{
@@ -80,7 +91,6 @@ and viewers cannot.
   - PruneWorker
   - HeartbeatWorker
   - DeleteWorker
-  - SetLogLevel
   - HijackContainer
   - ReportWorkerContainers
   - ReportWorkerVolumes
@@ -163,10 +173,8 @@ and viewers cannot.
   - ListPipelineBuilds
   - PipelineBadge
   - ListWorkers
-  - GetLogLevel
   - DownloadCLI
   - GetInfo
-  - GetInfoCreds
   - ListContainers
   - GetContainer
   - ListDestroyingContainers
@@ -245,6 +253,10 @@ and viewers cannot.
     \table-row{ListBuilds                   }{\reference{fly-builds}                                            }{n/a                                    }{✓                                }{✘           }
     \table-row{MainJobBadge                 }{n/a                                                               }{n/a                                    }{✓                                }{✘           }
     \table-row{GetLogLevel                  }{n/a                                                               }{n/a                                    }{✘                                }{✘           }
+    \table-row{SetLogLevel                  }{n/a                                                               }{n/a                                    }{✘                                }{✘           }
+    \table-row{GetWall                      }{n/a                                                               }{n/a                                    }{✓                                }{✘           }
+    \table-row{SetWall                      }{n/a                                                               }{n/a                                    }{✘                                }{✘           }
+    \table-row{ClearWall                    }{n/a                                                               }{n/a                                    }{✘                                }{✘           }
     \table-row{ListActiveUsersSince         }{\reference{fly-active-users}                                      }{n/a                                    }{✘                                }{✘           }
     \table-row{GetInfoCreds                 }{n/a                                                               }{n/a                                    }{✘                                }{✘           }
     \table-row{CheckResource                }{\reference{fly-check-resource}                                    }{check button on resource page          }{✘                                }{✓           }

--- a/lit/docs/operation/creds/aws-secretsmanager.lit
+++ b/lit/docs/operation/creds/aws-secretsmanager.lit
@@ -19,7 +19,7 @@
   attempt to use environment variables or the instance credentials assigned to
   the instance.
 
-  The web nodes's configuration specifies the following:
+  The web node's configuration specifies the following:
 
   \define-attribute{aws-secretsmanager-access-key: string}{
     A valid AWS access key.

--- a/lit/docs/operation/creds/aws-secretsmanager.lit
+++ b/lit/docs/operation/creds/aws-secretsmanager.lit
@@ -188,7 +188,7 @@
   As long as Concourse has permission to get the value of the
   \code{__concourse-health-check} secret, you should be able to measure an
   error rate by polling the \code{/api/v1/info/creds} endpoint when authenticated
-  as a cluster admin.
+  as a \reference{concourse-admin}.
 
   Depending on your workflow for updating secrets and your reliability
   requirements it may be worth \reference{creds-caching} and/or

--- a/lit/docs/operation/creds/aws-secretsmanager.lit
+++ b/lit/docs/operation/creds/aws-secretsmanager.lit
@@ -6,12 +6,20 @@
 \section{
   \title{Configuration}
 
-  The ATC is configured with an access key and secret key or session token and
-  the AWS region that your parameters are stored within. If no access key,
-  secret key, or session token is provided, Concourse will attempt to use
-  environment variables or the instance credentials assigned to the instance.
+  In order to integrate with AWS Secrets Manager for credential management, the
+  web node must be configured with:
 
-  The ATC's configuration specifies the following:
+  \list{
+    an access key and secret key, or a session token
+  }{
+    the AWS region that your parameters are stored within.
+  }
+
+  If no access key, secret key, or session token is provided, Concourse will
+  attempt to use environment variables or the instance credentials assigned to
+  the instance.
+
+  The web nodes's configuration specifies the following:
 
   \define-attribute{aws-secretsmanager-access-key: string}{
     A valid AWS access key.
@@ -80,12 +88,23 @@
 }
 
 \section{
-  \title{IAM Permissions}
+  \title{Saving credentials in AWS}
+
+  It seems to be best to use the 'other type of secret' option and the 'plaintext'
+  entry (otherwise your secrets will be interpolated as JSON) for best results.
+  Make sure your secret locations match the lookup templates exactly; include the
+  leading \code{/}, for example.
+}
+
+\section{
+  \title{IAM Permissions}{aws-secretsmanager-iam-permissions}
 
   The following is an example of an IAM policy that can be used to grant
   permissions to an IAM user or instance role. Note that the \code{Resource}
   section can contain a wildcard to a secret or be restricted to an
-  individual secret.
+  individual secret. In order for the health check to work properly (see
+  \reference{aws-secretsmanager-scaling}), Concourse needs to have access to the
+  \code{__concourse-health-check} secret.
 
   \codeblock{json}{{{
     {
@@ -107,17 +126,26 @@
                     "secretsmanager:DescribeSecret"
                 ],
                 "Resource": [
-                    "arn:aws:secretsmanager:::secret:/concourse/*",
-                    "arn:aws:secretsmanager:::secret:/concourse/TEAM_NAME/*",
-                    "arn:aws:secretsmanager:::secret:/concourse/TEAM_NAME/PIPELINE_NAME/*"
+                    "arn:aws:secretsmanager:*:*:secret:/concourse/*",
+                    "arn:aws:secretsmanager:*:*:secret:__concourse-health-check-??????"
                 ]
             }
         ]
     }
   }}}
 
-  Note that the \code{TEAM_NAME} and \code{PIPELINE_NAME} text above should be replaced to
-  fit your Concourse setup.
+  If you wish to restrict concourse to only have access to secrets for a
+  specific pipeline, you can replace
+  \code{"arn:aws:secretsmanager:*:*:secret:/concourse/*"} in the example above
+  with
+
+  \codeblock{json}{{{
+    "arn:aws:secretsmanager:*:*:secret:/concourse/TEAM_NAME/*",
+    "arn:aws:secretsmanager:*:*:secret:/concourse/TEAM_NAME/PIPELINE_NAME/*",
+  }}}
+
+  where \code{TEAM_NAME} and \code{PIPELINE_NAME} are replaced with the team and
+  name of the pipeline in question.
 
   For more information on how to use IAM roles to restrict access to Secrets Manager,
   review the
@@ -143,4 +171,26 @@
   The leading \code{/concourse} can be changed by specifying
   \code{--aws-secretsmanager-pipeline-secret-template} or
   \code{--aws-secretsmanager-team-secret-template} variables.
+
+  Note that if Concourse does not have
+  \reference{aws-secretsmanager-iam-permissions}{permission} to access the
+  pipeline-scoped paths, then credential lookups will fail even for credentials
+  which are stored at the team level.
+}
+
+\section{
+  \title{Scaling}{aws-secretsmanager-scaling}
+
+  If your cluster has a large workload, in particular if there are many resources,
+  Concourse can generate a lot of traffic to AWS and subsequently get
+  rate-limited.
+
+  As long as Concourse has permission to get the value of the
+  \code{__concourse-health-check} secret, you should be able to measure an
+  error rate by polling the \code{/api/v1/info/creds} endpoint when authenticated
+  as a cluster admin.
+
+  Depending on your workflow for updating secrets and your reliability
+  requirements it may be worth \reference{creds-caching} and/or
+  \reference{creds-retry-logic} to mitigate rate-limit-related errors.
 }


### PR DESCRIPTION
* clarify that a region is always required, but authentication can be done
  either via an access/secret key or a session token.
* The example IAM policy was incorrect -- per
  https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html#permissions_grant-limited-resources:
  > If you don’t care about the region or account that owns a secret, you must
  > specify a wildcard character * , not an empty field, for the region and
  > account ID number fields of the ARN.
* give tips on writing secrets in the AWS console
* describe the health check and warn about rate-limiting.