### PR TITLE
Fix typo of concouse to concourse

### DIFF
--- a/lit/docs/resources.lit
+++ b/lit/docs/resources.lit
@@ -8,7 +8,7 @@ inputs to and outputs of \reference{jobs}{jobs} in the pipeline.
 
 Each resource represents a versioned artifact with an external source of truth.
 Configuring the same resource in any pipeline on any Concourse cluster will
-behave the exact same way. Concouse will continuously \code{check} each
+behave the exact same way. Concourse will continuously \code{check} each
 configured resource to discover new versions. These versions then flow through
 the pipeline via \reference{get-step}s configured on \reference{jobs}.
 


### PR DESCRIPTION
Just fixing a small typo I noticed while reading docs.