### PR TITLE
Correct GoatCounter integration for search

### DIFF
--- a/html/top.tmpl
+++ b/html/top.tmpl
@@ -16,7 +16,7 @@
 
     app.ports.emitSearchTerm.subscribe(function(term) {
       goatcounter.count({
-        event: "search:"+term,
+        path: "search:" + term,
         title: "user searched: " + term,
         event: true
       });


### PR DESCRIPTION
Also emailed this, but figured I might as well create a PR: the "event"
key is a boolean to indicate it's an event, and the event name is stored
in the "path" (this is a bit confusing; it's one of those legacy compat.
things).