### PR TITLE
Replace docker-image with registry-image

### DIFF
--- a/lit/docs/jobs/steps.lit
+++ b/lit/docs/jobs/steps.lit
@@ -192,13 +192,13 @@ by configuring \reference{schema.step.on_failure} or
           \codeblock{yaml}{{{
           plan:
           - put: resource-image
-            resource: docker-image-resource
+            resource: registry-image-resource
           }}}
 
           Additionally, you can control the settings of the implicit \code{get} step
           by setting \code{get_params}. For example, if you did not want a \code{put}
-          step utilizing the \link{ \code{docker-image} resource
-          type}{https://github.com/concourse/docker-image-resource} to download the
+          step utilizing the \link{ \code{registry-image} resource
+          type}{https://github.com/concourse/registry-image-resource} to download the
           image, you would implement your \code{put} step as such:
 
           \codeblock{yaml}{{{
@@ -357,7 +357,7 @@ by configuring \reference{schema.step.on_failure} or
             source: {uri: https://github.com/my-user/my-project}
 
           - name: my-task-image
-            type: docker-image
+            type: registry-image
             source: {repository: my-user/my-repo}
 
           jobs:
@@ -439,7 +439,7 @@ by configuring \reference{schema.step.on_failure} or
             platform: linux
 
             image_resource:
-              type: docker-image
+              type: registry-image
               source:
                 repository: my.local.registry:8080/my/image
                 username: ((myuser))
@@ -648,7 +648,7 @@ by configuring \reference{schema.step.on_failure} or
           \codeblock{yaml}{{{
           resources:
           - name: task-image
-              type: docker-image
+              type: registry-image
               source:
                 repository: my.local.registry:8080/my/image
                 username: ((myuser))

--- a/lit/docs/pipelines.lit
+++ b/lit/docs/pipelines.lit
@@ -98,7 +98,7 @@ files} which conform to the following schema:
           config:
             platform: linux
             image_resource:
-              type: docker-image
+              type: registry-image
               source: {repository: alpine}
             run:
               path: echo
@@ -177,7 +177,7 @@ files} which conform to the following schema:
       ---
       resource_types:
       - name: rss
-        type: docker-image
+        type: registry-image
         source:
           repository: suhlig/concourse-rss-resource
           tag: latest

--- a/lit/docs/resource-types.lit
+++ b/lit/docs/resource-types.lit
@@ -44,9 +44,9 @@ A pipeline's resource types are listed under
     by resource type, and is a black box to Concourse; it is blindly passed to
     the resource at runtime.
 
-    To use \code{docker-image} as an example, the source would contain something
-    like \code{repository: username/reponame}. See the \link{Docker Image
-    resource}{https://github.com/concourse/docker-image-resource} (or whatever
+    To use \code{registry-image} as an example, the source would contain something
+    like \code{repository: username/reponame}. See the \link{Registry Image
+    resource}{https://github.com/concourse/registry-image-resource} (or whatever
     resource type your resource type uses) for more information.
   }
 
@@ -103,7 +103,7 @@ A pipeline's resource types are listed under
     ---
     resource_types:
     - name: rss
-      type: docker-image
+      type: registry-image
       source:
         repository: suhlig/concourse-rss-resource
         tag: latest

--- a/lit/docs/tasks.lit
+++ b/lit/docs/tasks.lit
@@ -264,7 +264,7 @@ A task's configuration specifies the following:
   platform: linux
 
   image_resource:
-    type: docker-image
+    type: registry-image
     source:
       repository: ruby
       tag: '2.1'
@@ -374,7 +374,7 @@ A task's configuration specifies the following:
     platform: linux
 
     image_resource:
-      type: docker-image
+      type: registry-image
       source:
         repository: my.local.registry:8080/my/image
         username: ((myuser))

--- a/lit/docs/tasks/environment.lit
+++ b/lit/docs/tasks/environment.lit
@@ -41,7 +41,7 @@ Putting all this together, the following task config:
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: golang
     tag: '1.6'

--- a/lit/examples/attic/dockerhub.lit
+++ b/lit/examples/attic/dockerhub.lit
@@ -6,7 +6,7 @@
 \section{
   \title{}{pipeline}
 
-	You can use the docker-image resource to compile and test Dockerfiles.
+	You can use the registry-image resource to compile and test Dockerfiles.
 
 	\frame{https://ci.concourse-ci.org/teams/examples/pipelines/job}
 }
@@ -22,7 +22,7 @@ resources:
       uri: https://github.com/concourse/mock-resource
 
   - name: dockerhub-edge
-    type: docker-image
+    type: registry-image
     source:
       tag: example-edge
       repository: concourse/docs


### PR DESCRIPTION
Since we plan on depracting docker-image and we'd prefer for people to
use and give feedback on registry-image resource instead.

I simply `ag`'d for `docker-image` and replaced all instances where it made sense to replace.

closes concourse/concourse#5678