### PR TITLE
Clarify how the out script receives resources

### DIFF
--- a/lit/docs/resource-types/implementing.lit
+++ b/lit/docs/resource-types/implementing.lit
@@ -162,9 +162,9 @@ UI, so you should make your output pretty.
 \section{
   \title{\code{out}\aux{: Update a resource.}}{resource-out}
 
-  The \code{out} script is called with a path to the directory containing the
-  build's full set of sources as the first argument, and is given on \code{stdin} the
-  configured params and the resource's source configuration.
+  The \code{out} script is passed a path to the directory containing the
+  build's full set of sources as command line argument \code{$1}, and
+  is given on \code{stdin} the configured params and the resource's source configuration.  
 
   The script must emit the resulting version of the resource. For example, the
   \code{git} resource emits the SHA of the commit that it has just pushed.


### PR DESCRIPTION
Use a similar wording to the in script to indicate it receives this as command line argument $1.