### PR TITLE
update github auth call back url doc

### DIFF
--- a/lit/docs/auth/configuring/github.lit
+++ b/lit/docs/auth/configuring/github.lit
@@ -12,9 +12,8 @@ model and other security improvements in their infrastructure.
   First, you'll need to \link{create an OAuth application on
   GitHub}{https://github.com/settings/applications/new}.
 
-  The "Authorization callback URL" must be the URL of your Concourse server
-  with \code{/sky/issuer/callback} appended. This address must be reachable by
-  GitHub - it can't be \code{localhost}.
+  The "Authorization callback URL" must be the URL of your Concourse server.
+  This address must be reachable by GitHub - it can't be \code{localhost}.
 
   For example, Concourse's own CI server's callback URL would be:
 


### PR DESCRIPTION
with updated DEX https://github.com/dexidp/dex/pull/1700, the Github
App for Concourse doesn't need to be configured with an
`{concourse_server_url}/sky/issuer/callback` anymore. As long as the
server URL matches it will work, see details in
[Github Oauth Doc](https://docs.github.com/en/developers/apps/authorizing-oauth-apps#redirect-urls).

Signed-off-by: Rui Yang <ryang@pivotal.io>