### PR TITLE
Remove latest-rc override

### DIFF
--- a/latest-rc.override.yml
+++ b/latest-rc.override.yml
@@ -1,5 +1,0 @@
-version: '3'
-
-services:
-  concourse:
-    image: concourse/concourse-rc:latest


### PR DESCRIPTION
Moved it to the ci repo where it's actually being used.

https://github.com/concourse/ci/blob/master/overrides/docker-compose.latest-rc.yml