### PR TITLE
Add Clarification for Vault Paths with Many Levels

### DIFF
--- a/lit/docs/operation/creds/vault.lit
+++ b/lit/docs/operation/creds/vault.lit
@@ -41,6 +41,9 @@ quite involved.
   default to the field name \code{value}. You can specify the field to grab via
   \code{.} syntax, e.g. \code{((foo.bar))}.
 
+  If you have multiple, intermediate levels in your path, you can use the \code{/}
+  separator to reach your intended field, e.g. \code{((foo/bar/baz.qux))}.
+
   When executing a one-off task, there is no pipeline: so in this case, only the
   team path \code{/concourse/TEAM_NAME/foo} is searched.
 


### PR DESCRIPTION
This adds a tiny example of how to use the `/` separator to traverse a
Vault path. The intention is to make it clear that the `.` is the field
separator and should not be used as `((foo.bar.baz.quz))`.