### PR TITLE
Remove cc.xml example

### DIFF
--- a/lit/docs/observation.lit
+++ b/lit/docs/observation.lit
@@ -23,9 +23,6 @@ your pipelines.
   \code{{{
   /api/v1/teams/{team}/cc.xml
   }}}
-
-  For example: \link{the \code{main} team
-  \code{cc.xml}}{http://ci.concourse-ci.org/api/v1/teams/main/cc.xml}.
 }
 
 \section{


### PR DESCRIPTION
Explicit URL `http://ci.concourse-ci.org/api/v1/teams/main/cc.xml` appears inaccessible with message `not authorized` - presumably to all but `ci.concourse-ci.org` staff. 

Happy to edit with a different example if suggested.