### PR TITLE
update-beginning-tutorial-docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,8 @@ services:
       CONCOURSE_MAIN_TEAM_LOCAL_USER: test
       # instead of relying on the default "detect"
       CONCOURSE_WORKER_BAGGAGECLAIM_DRIVER: overlay
-      # docker puts the dns server at 127.0.0.*, which cannot be accessed by the containerd containers
-      CONCOURSE_WORKER_CONTAINERD_DNS_PROXY_ENABLE: "true"
       CONCOURSE_CLIENT_SECRET: Y29uY291cnNlLXdlYgo=
       CONCOURSE_TSA_CLIENT_SECRET: Y29uY291cnNlLXdvcmtlcgo=
       CONCOURSE_X_FRAME_OPTIONS: allow
       CONCOURSE_CLUSTER_NAME: tutorial
+      CONCOURSE_WORKER_CONTAINERD_DNS_SERVER: "8.8.8.8"


### PR DESCRIPTION
@taylorsilva and I troubleshot an issue where, when you `wget` the latest version of this docker-compose file, it will fail to fetch any image resources that are needed to run all of the basic pipelines.

Updating this docker-compose so that it will prevent this for newcomers to concourse.

![image](https://user-images.githubusercontent.com/42812387/122118058-78e98080-cddc-11eb-8ff1-b99386b15725.png)
