### PR TITLE
Document `across` and add multi-branch workflows guide

### DIFF
--- a/lit/docs/config/basic-schemas.lit
+++ b/lit/docs/config/basic-schemas.lit
@@ -60,6 +60,22 @@ just here for completeness!
   but...please don't.
 }
 
+\schema{value}{
+  An arbitrary YAML value. May be a \reference{schema.number},
+  \reference{schema.string}, \reference{schema.boolean},
+  \reference{schema.config}, or a \code{[\reference{schema.value}]}.
+
+  \codeblock{yaml}{{{
+  values:
+  - 123
+  - bar
+  - true
+  - key1: abc
+    key2: def
+  - [hello, world]
+  }}}
+}
+
 \schema{identifier}{
   An \italic{identifier} is a string value. The following defines the allowed
   character set for an \italic{identifier}:

--- a/lit/docs/guides/git.lit
+++ b/lit/docs/guides/git.lit
@@ -139,3 +139,203 @@
     }}
   }
 }
+
+\section{
+  \title{Multi-Branch Workflows}{multi-branch-workflows}
+  \omit-children-from-table-of-contents
+
+  Teams may make use of multiple branches for their development. For instance,
+  some teams create feature branches while working on new functionality - once
+  this functionality is ready, the branch will be merged into the main branch
+  and the feature branch will be deleted.
+
+  While a feature is under development, you'll often want to run tests against
+  the feature branch and possibly deploy to a staging environment. To model this
+  in Concourse, you'll need to have a pipeline for each active feature branch.
+  Manually setting (and eventually archiving) a pipeline for each feature branch
+  would be quite a burden. For this type of workflow, Concourse has a few
+  important tools to help you out: the \reference{set-pipeline-step},
+  \reference{schema.step.across}, and \reference{instanced-pipelines}{instanced
+  pipelines}.
+
+  \warn{
+    \reference{schema.step.across} and \reference{instanced-pipelines}{instanced pipelines}
+    are both experimental features, and must be enabled with the feature flags
+    \code{CONCOURSE_ENABLE_ACROSS_STEP} and \code{CONCOURSE_ENABLE_PIPELINE_INSTANCES}, respectively.
+  }
+
+  In this guide, we'll cover:
+
+  \ordered-list{
+    Writing a pipeline to \reference{multi-branch-test-build-deploy} a branch
+    to a staging environment. We'll use \link{Terraform}{https://www.terraform.io/}
+    for our deployment
+  }{
+    \reference{multi-branch-tracking-branches} in a repository; for each
+    branch, we'll set a pipeline (using the \reference{set-pipeline-step} and
+    \reference{schema.step.across})
+  }{
+    Automatically \reference{multi-branch-cleaning-up} after branches get
+    merged or deleted
+  }
+
+  \section{
+    \title{Test, Build & Deploy}{multi-branch-test-build-deploy}
+
+    We'll start out by defining the pipeline that should run for each active
+    branch. For this example, we'll be working with the following \link{sample Go
+    application}{https://github.com/concourse/examples/tree/master/apps/golang}.
+
+    Our pipeline will have three stages:
+
+    \ordered-list{
+      Run unit tests
+    }{
+      Build and upload a binary to a blobstore (in our case, we'll use
+      \link{Google Cloud Storage}{https://cloud.google.com/storage})
+    }{
+      Trigger a \code{terraform apply} to deploy our app to a staging
+      environment. The \link{Terraform module}{https://github.com/aoldershaw/examples/blob/master/terraform/staging/main.tf}
+      we'll use here doesn't actually provision any infrastructure, and is just used
+      as an example
+    }
+
+    Since the pipeline config is intended to be used as a template for multiple
+    different branches, we can use \reference{vars} to parameterize the config.
+    In particular, we'll use the vars \code{((feature))} and \code{((branch))},
+    which represent the name of the feature and the name of the branch, respectively.
+
+    Below is the full pipeline config:
+
+    \link{\code{examples/pipelines/multi-branch/template.yml}}{https://github.com/aoldershaw/examples/blob/master/pipelines/multi-branch/template.yml}
+    \remote-codeblock{yaml}{https://raw.githubusercontent.com/aoldershaw/examples/master/pipelines/multi-branch/template.yml}
+  }
+
+  \section{
+    \title{Tracking Branches}{multi-branch-tracking-branches}
+
+    In addition to the branch pipeline template, we'll also need a pipeline to
+    track the list of branches and set a pipeline for each one.
+
+    To track the list of branches in a repository, we can use
+    \link{aoldershaw/git-branches-resource}{https://github.com/aoldershaw/git-branches-resource}.
+    This \reference{resource-types}{\code{resource_type}} emits a new
+    \reference{resource-versions}{resource version} whenever a branch is created or
+    deleted. It also lets us filter the list of branches by a regular expression.
+    In this case, let's assume our feature branches match the regular expression
+    \code{feature/.*}.
+
+    Below is the full pipeline config for this tracker pipeline:
+
+    \link{\code{examples/pipelines/multi-branch/tracker.yml}}{https://github.com/aoldershaw/examples/blob/master/pipelines/multi-branch/tracker.yml}
+    \codeblock{yaml}{{{
+      resource_types:
+      - name: git-branches
+        type: registry-image
+        source:
+          repository: aoldershaw/git-branches-resource
+
+      resources:
+      - name: feature-branches
+        type: git-branches
+        source:
+          uri: https://github.com/concourse/examples
+          branch_regex: 'feature/(?P<feature>.*)'
+
+      - name: examples
+        type: git
+        source:
+          uri: https://github.com/concourse/examples
+
+      jobs:
+      - name: set-feature-pipelines
+        plan:
+        - in_parallel:
+          - get: feature-branches
+            trigger: true
+          - get: examples
+        - load_var: branches
+          file: feature-branches/branches.json
+        - across:
+          - var: branch
+            values: ((.:branches))
+          set_pipeline: dev
+          file: examples/pipelines/multi-branch/template.yml
+          instance_vars: {feature: ((.:branch.groups.feature))}
+          vars: {branch: ((.:branch.name))}
+    }}}
+
+    We set each pipeline as an \reference{instanced-pipelines}{instanced
+    pipeline} - this will result in Concourse grouping all of the related
+    \code{dev} pipelines in the UI.
+  }
+
+  \section{
+    \title{Cleaning Up Old Workspaces}{multi-branch-cleaning-up}
+
+    With the setup described in \reference{multi-branch-tracking-branches},
+    Concourse will automatically archive any pipelines for branches that get
+    removed. However, Concourse doesn't know that it should destroy Terraform
+    workspaces when a branch is removed. To accomplish this, we can add another
+    job to the tracker pipeline that removes any Terraform workspaces that
+    don't belong to an active branch.
+
+    \link{\code{examples/pipelines/multi-branch/tracker.yml}}{https://github.com/aoldershaw/examples/blob/master/pipelines/multi-branch/tracker.yml}
+    \codeblock{yaml}{{{
+      ...
+
+      jobs:
+      - name: set-feature-pipelines
+        ...
+
+      - name: cleanup-inactive-workspaces
+        plan:
+        - get: feature-branches
+          passed: [set-feature-pipelines]
+          trigger: true
+        - load_var: active_branches
+          file: feature-branches/branches.json
+        - task: cleanup
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source: {repository: hashicorp/terraform}
+            params:
+              ACTIVE_BRANCHES: ((.:active_branches))
+              TERRAFORM_BACKEND_CONFIG:
+                terraform:
+                  backend:
+                    gcs:
+                      bucket: concourse-examples
+                      prefix: multi-branch/terraform
+                      credentials: ((concourse_artifacts_json_key))
+            run:
+              path: sh
+              args:
+              - -c
+              - |
+                set -euo pipefail
+
+                apk add jq
+
+                active_features="$(echo "$ACTIVE_BRANCHES" | jq '[.[].groups.feature]')"
+
+                echo "$TERRAFORM_BACKEND_CONFIG" > backend.tf.json
+                terraform init
+                active_workspaces="$(terraform workspace list | grep -v '^[*]' | tr -d ' ' | jq --raw-input --slurp 'split("\n") | map(select(. != ""))')"
+
+                jq -nr "$active_workspaces - $active_features | .[]" | while read extra_workspace
+                do
+                  echo "deleting workspace $extra_workspace"
+                  terraform workspace select "$extra_workspace"
+                  terraform init
+
+                  terraform destroy -auto-approve
+
+                  terraform workspace select default
+                  terraform workspace delete "$extra_workspace"
+                done
+    }}}
+  }
+}

--- a/lit/docs/guides/git.lit
+++ b/lit/docs/guides/git.lit
@@ -240,6 +240,11 @@
         type: git-branches
         source:
           uri: https://github.com/concourse/examples
+          # The "(?P<name>pattern)" syntax defines a named capture group.
+          # aoldershaw/git-branches-resource emits the value of each named capture
+          # group under the `groups` key.
+          #
+          # e.g. feature/some-feature ==> {"groups": {"feature": "some-feature"}}
           branch_regex: 'feature/(?P<feature>.*)'
 
       - name: examples
@@ -307,7 +312,7 @@
           backend_config: &terraform_backend_config
             bucket: concourse-examples
             prefix: multi-branch/terraform
-            credentials: ((concourse_artifacts_json_key))
+            credentials: ((gcp_service_account_key))
 
       jobs:
       - name: set-feature-pipelines

--- a/lit/docs/guides/git.lit
+++ b/lit/docs/guides/git.lit
@@ -195,7 +195,7 @@
       \link{Google Cloud Storage}{https://cloud.google.com/storage})
     }{
       Trigger a \code{terraform apply} to deploy our app to a staging
-      environment. The \link{Terraform module}{https://github.com/aoldershaw/examples/blob/master/terraform/staging/main.tf}
+      environment. The \link{Terraform module}{https://github.com/concourse/examples/blob/master/terraform/staging/main.tf}
       we'll use here doesn't actually provision any infrastructure, and is just used
       as an example
     }
@@ -207,8 +207,8 @@
 
     Below is the full pipeline config:
 
-    \link{\code{examples/pipelines/multi-branch/template.yml}}{https://github.com/aoldershaw/examples/blob/master/pipelines/multi-branch/template.yml}
-    \remote-codeblock{yaml}{https://raw.githubusercontent.com/aoldershaw/examples/master/pipelines/multi-branch/template.yml}
+    \link{\code{examples/pipelines/multi-branch/template.yml}}{https://github.com/concourse/examples/blob/master/pipelines/multi-branch/template.yml}
+    \remote-codeblock{yaml}{https://raw.githubusercontent.com/concourse/examples/master/pipelines/multi-branch/template.yml}
   }
 
   \section{
@@ -227,7 +227,7 @@
 
     Below is the full pipeline config for this tracker pipeline:
 
-    \link{\code{examples/pipelines/multi-branch/tracker.yml}}{https://github.com/aoldershaw/examples/blob/master/pipelines/multi-branch/tracker.yml}
+    \link{\code{examples/pipelines/multi-branch/tracker.yml}}{https://github.com/concourse/examples/blob/master/pipelines/multi-branch/tracker.yml}
     \codeblock{yaml}{{{
       resource_types:
       - name: git-branches
@@ -287,7 +287,7 @@
     that figures out which workspaces don't belong to an active branch and
     destroy them.
 
-    \link{\code{examples/pipelines/multi-branch/tracker.yml}}{https://github.com/aoldershaw/examples/blob/master/pipelines/multi-branch/tracker.yml}
+    \link{\code{examples/pipelines/multi-branch/tracker.yml}}{https://github.com/concourse/examples/blob/master/pipelines/multi-branch/tracker.yml}
     \codeblock{yaml}{{{
       resource_types:
       - name: git-branches

--- a/lit/docs/guides/git.lit
+++ b/lit/docs/guides/git.lit
@@ -276,13 +276,38 @@
     With the setup described in \reference{multi-branch-tracking-branches},
     Concourse will automatically archive any pipelines for branches that get
     removed. However, Concourse doesn't know that it should destroy Terraform
-    workspaces when a branch is removed. To accomplish this, we can add another
-    job to the tracker pipeline that removes any Terraform workspaces that
-    don't belong to an active branch.
+    workspaces when a branch is removed. To accomplish this, we can yet again
+    make use of the \link{Terraform resource}{https://github.com/ljfranklin/terraform-resource}
+    to destroy these workspaces. We'll add another job to the tracker pipeline
+    that figures out which workspaces don't belong to an active branch and
+    destroy them.
 
     \link{\code{examples/pipelines/multi-branch/tracker.yml}}{https://github.com/aoldershaw/examples/blob/master/pipelines/multi-branch/tracker.yml}
     \codeblock{yaml}{{{
-      ...
+      resource_types:
+      - name: git-branches
+        ...
+
+      - name: terraform
+        type: registry-image
+        source:
+          repository: ljfranklin/terraform-resource
+
+      resources:
+      - name: feature-branches
+        ...
+
+      - name: examples
+        ...
+
+      - name: staging-env
+        type: terraform
+        source:
+          backend_type: gcs
+          backend_config: &terraform_backend_config
+            bucket: concourse-examples
+            prefix: multi-branch/terraform
+            credentials: ((concourse_artifacts_json_key))
 
       jobs:
       - name: set-feature-pipelines
@@ -290,26 +315,24 @@
 
       - name: cleanup-inactive-workspaces
         plan:
-        - get: feature-branches
-          passed: [set-feature-pipelines]
-          trigger: true
-        - load_var: active_branches
-          file: feature-branches/branches.json
-        - task: cleanup
+        - in_parallel:
+          - get: feature-branches
+            passed: [set-feature-pipelines]
+            trigger: true
+          - get: examples
+        - task: find-inactive-workspaces
           config:
             platform: linux
             image_resource:
               type: registry-image
               source: {repository: hashicorp/terraform}
+            inputs:
+            - name: feature-branches
+            outputs:
+            - name: extra-workspaces
             params:
-              ACTIVE_BRANCHES: ((.:active_branches))
               TERRAFORM_BACKEND_CONFIG:
-                terraform:
-                  backend:
-                    gcs:
-                      bucket: concourse-examples
-                      prefix: multi-branch/terraform
-                      credentials: ((concourse_artifacts_json_key))
+                gcs: *terraform_backend_config
             run:
               path: sh
               args:
@@ -317,25 +340,29 @@
               - |
                 set -euo pipefail
 
-                apk add jq
+                apk add -q jq
 
-                active_features="$(echo "$ACTIVE_BRANCHES" | jq '[.[].groups.feature]')"
+                active_features="$(jq '[.[].groups.feature]' feature-branches/branches.json)"
 
-                echo "$TERRAFORM_BACKEND_CONFIG" > backend.tf.json
+                jq -n "{terraform: {backend: $TERRAFORM_BACKEND_CONFIG}}" > backend.tf.json
                 terraform init
+
+                # List all active workspaces, ignoring the default workspace
                 active_workspaces="$(terraform workspace list | grep -v '^[*]' | tr -d ' ' | jq --raw-input --slurp 'split("\n") | map(select(. != ""))')"
 
-                jq -nr "$active_workspaces - $active_features | .[]" | while read extra_workspace
-                do
-                  echo "deleting workspace $extra_workspace"
-                  terraform workspace select "$extra_workspace"
-                  terraform init
-
-                  terraform destroy -auto-approve
-
-                  terraform workspace select default
-                  terraform workspace delete "$extra_workspace"
-                done
-    }}}
-  }
+                jq -n "$active_workspaces - $active_features" > extra-workspaces/workspaces.json
+        - load_var: extra_workspaces
+          file: extra-workspaces/workspaces.json
+        - across:
+          - var: workspace
+            values: ((.:extra_workspaces))
+          put: staging-env
+          params:
+            terraform_source: examples/terraform/staging
+            env_name: ((.:workspace))
+            action: destroy
+          get_params:
+            action: destroy
+          }}}
+        }
 }

--- a/lit/docs/jobs/steps.lit
+++ b/lit/docs/jobs/steps.lit
@@ -1041,8 +1041,7 @@ by configuring \reference{schema.step.on_failure} or
   }
 
   \optional-attribute{across}{[across_var]}{
-    Run a wrapped step multiple times with different combinations of variable
-    values.
+    Run a step multiple times with different combinations of variable values.
 
     \warn{
       \code{across} is considered an \bold{experimental} feature, and its
@@ -1054,7 +1053,8 @@ by configuring \reference{schema.step.on_failure} or
       \required-attribute{var}{identifier}{
         The name of the variable that will be added to the
         \reference{local-vars}{"\code{.}" var source}. This variable will only be
-        accessible in the scope of the wrapped step.
+        accessible in the scope of the step - each iteration of the step gets
+        its own scope.
 
         If a variable of the same name already exists in the parent scope, a
         warning will be printed.

--- a/lit/docs/jobs/steps.lit
+++ b/lit/docs/jobs/steps.lit
@@ -25,6 +25,9 @@ A build plan is a sequence of \italic{steps}:
 }{
   the \reference{do-step} runs steps in sequence
 }{
+  the \reference{schema.step.across}{\code{across} step modifier} runs a step
+  multiple times; once for each combination of variable values
+}{
   the \reference{try-step} attempts to run a step and succeeds even if the step
   fails
 }
@@ -1034,6 +1037,148 @@ by configuring \reference{schema.step.on_failure} or
           }}}
         }
       }
+    }
+  }
+
+  \optional-attribute{across}{[across_var]}{
+    Run a wrapped step multiple times with different combinations of variable
+    values.
+
+    \warn{
+      \code{across} is considered an \bold{experimental} feature, and its
+      syntax/semantics may change. To enable \code{across} for your deployment,
+      you must set the feature flag \code{CONCOURSE_ENABLE_ACROSS_STEP}.
+    }
+
+    \schema{across_var}{
+      \required-attribute{var}{identifier}{
+        The name of the variable that will be added to the
+        \reference{local-vars}{"\code{.}" var source}. This variable will only be
+        accessible in the scope of the wrapped step.
+
+        If a variable of the same name already exists in the parent scope, a
+        warning will be printed.
+      }
+
+      \required-attribute{values}{[value]}{
+        The list of values that the \reference{schema.across_var.var}{var} will
+        iterate over when running the substep. If multiple \reference{schema.across_var}{vars}
+        are configured, all combinations of values across all vars will run.
+
+        The list of values may also be interpolated. For instance, you may use
+        the \reference{load-var-step} to first load a list of \reference{schema.value}
+        into a \reference{local-vars}{local var}, and then iterate across that dynamic
+        list of values.
+
+        \example-toggle{Value combinations}{
+          The following \reference{schema.step.across} will run the task
+          \code{foo/build.yml} for each package defined in \code{foo/packages-to-build.json}
+          with Go 1.15 and 1.16.
+
+          \codeblock{yaml}{{{
+          plan:
+          - get: foo
+          - load_var: packages
+            file: foo/packages-to-build.json
+          - across:
+            - var: package
+              values: ((.:packages))
+            - var: go_version
+              values: ['1.15', '1.16']
+            task: build
+            file: foo/build.yml
+            vars:
+              go_version: ((.:go_version))
+              package: ((.:package))
+          }}}
+
+          Supposing \code{foo/packages-to-build.json} had the following content:
+          \codeblock{json}{{{
+          ["./cmd/first", "./cmd/second", "./cmd/third"]
+          }}}
+
+          ...then the task \code{foo/build.yml} would be run with the following
+          var combinations:
+
+          \list{
+            \code{\{package: "./cmd/first", go_version: "1.15"\}}
+          }{
+            \code{\{package: "./cmd/first", go_version: "1.16"\}}
+          }{
+            \code{\{package: "./cmd/second", go_version: "1.15"\}}
+          }{
+            \code{\{package: "./cmd/second", go_version: "1.16"\}}
+          }{
+            \code{\{package: "./cmd/third", go_version: "1.15"\}}
+          }{
+            \code{\{package: "./cmd/third", go_version: "1.16"\}}
+          }
+        }
+      }
+
+      \optional-attribute{max_in_flight}{`all` | number}{
+        \italic{Default \code{1}.} If set to \code{all}, the substep will run
+        with all combinations of the current var in parallel. If set to a
+        \reference{schema.number}, only that number of substeps may run in parallel.
+
+        \example-toggle{Multiple vars}{
+          If multiple \reference{schema.across_var}{vars} are configured, the
+          effective \code{max_in_flight} is multiplicative. For instance:
+
+          \codeblock{yaml}{{{
+          plan:
+          - across:
+            - var: var1
+              values: [a, b, c]
+              max_in_flight: all
+            - var: var2
+              values: [1, 2]
+            - var: var3
+              values: [foo, bar]
+              max_in_flight: 2
+          }}}
+
+          Here, \bold{6 substeps} will run in parallel, since all 3 of
+          \code{var1}'s values can run in parallel, and 2 of \code{var3}'s
+          values can run in parallel.
+        }
+      }
+
+      \optional-attribute{fail_fast}{boolean}{
+        \italic{Default \code{false}.} When enabled, the \code{across} step will
+        fail fast by returning as soon as any sub-step fails. This means that running steps
+        will be interrupted and pending steps will no longer be scheduled.
+      }
+    }
+
+    The \code{across} step can be combined with the \reference{load-var-step},
+    the \reference{set-pipeline-step}, and \reference{instanced-pipelines}{instanced pipelines}
+    to maintain a dynamically sized group of related pipelines.
+
+    \example-toggle{Multi-branch workflows}{
+      You can use the \code{across} step to set a pipeline for each branch in a
+      git repository.
+
+      \codeblock{yaml}{{{
+      plan:
+      - get: release-branches
+        trigger: true
+      - get: ci
+      - load_var: branches
+        file: release-branches/branches.json
+      - across:
+        - var: branch
+          values: ((.:branches))
+        set_pipeline: release
+        file: ci/pipelines/release.yml
+        instance_vars: {branch: ((.:branch.name))}
+      }}}
+
+      When a new branch is added, a new pipeline will be created. When a branch
+      is deleted, the pipeline will be automatically archived as described in
+      the \reference{set-pipeline-step}.
+
+      For a more complete example, refer to \reference{multi-branch-workflows}.
     }
   }
 


### PR DESCRIPTION
Depends on https://github.com/concourse/examples/pull/4

![localhost_3000_multi-branch-workflows html](https://user-images.githubusercontent.com/26583442/126356637-46552ec6-89d6-4659-8ebe-44b90b690683.png)
