### PR TITLE
docs: Fixes one typo & corrects spelling of GitHub

### DIFF
--- a/lit/docs/getting-started.lit
+++ b/lit/docs/getting-started.lit
@@ -13,7 +13,7 @@ Before getting started you should have the following installed:
 }
 
 This tutorial assumes you understand what Linux containers are and how to work
-with them. If you know what a Dockfile is and how to make your own then you're
+with them. If you know what a Dockerfile is and how to make your own then you're
 probably good to jump into this tutorial. If you're not familiar with Linux
 containers then you may want to \link{get started with
 Docker}{https://docs.docker.com/get-started/} first before diving into this
@@ -24,7 +24,7 @@ It will also help if you know how to read YAML. We have a quick
 
 \aside{
   If you have any feedback for this tutorial please share it in \link{this
-  Github discussion}{https://github.com/concourse/concourse/discussions/7353}
+  GitHub discussion}{https://github.com/concourse/concourse/discussions/7353}
 }
 
 \table-of-contents

--- a/lit/docs/getting-started/hello-world.lit
+++ b/lit/docs/getting-started/hello-world.lit
@@ -203,6 +203,6 @@
 
   \aside{
     If you have any feedback for this tutorial please share it in \link{this
-    Github discussion}{https://github.com/concourse/concourse/discussions/7353}
+    GitHub discussion}{https://github.com/concourse/concourse/discussions/7353}
   }
 }

--- a/lit/docs/getting-started/inputs-outputs.lit
+++ b/lit/docs/getting-started/inputs-outputs.lit
@@ -185,6 +185,6 @@
 
   \aside{
     If you have any feedback for this tutorial please share it in \link{this
-    Github discussion}{https://github.com/concourse/concourse/discussions/7353}
+    GitHub discussion}{https://github.com/concourse/concourse/discussions/7353}
   }
 }

--- a/lit/docs/getting-started/quickstart.lit
+++ b/lit/docs/getting-started/quickstart.lit
@@ -83,6 +83,6 @@
 
     \aside{
       If you have any feedback for this tutorial please share it in \link{this
-      Github discussion}{https://github.com/concourse/concourse/discussions/7353}
+      GitHub discussion}{https://github.com/concourse/concourse/discussions/7353}
     }
 }

--- a/lit/docs/getting-started/resources.lit
+++ b/lit/docs/getting-started/resources.lit
@@ -688,6 +688,6 @@
 
   \aside{
     If you have any feedback for this tutorial please share it in \link{this
-    Github discussion}{https://github.com/concourse/concourse/discussions/7353}
+    GitHub discussion}{https://github.com/concourse/concourse/discussions/7353}
   }
 }

--- a/lit/docs/guides/git.lit
+++ b/lit/docs/guides/git.lit
@@ -13,7 +13,7 @@
   image. That image is probably the most popular git resource for Concourse
   since it is shipped in the
   \link{concourse/concourse}{https://hub.docker.com/r/concourse/concourse}
-  image and in the tarball on the \link{Github release
+  image and in the tarball on the \link{GitHub release
   page}{https://github.com/concourse/concourse/releases}. It is not the only
   resource available for working with git-related resources. If you don't see
   your use-case on this page then there is probably another resource that you

--- a/lit/docs/install/upgrading.lit
+++ b/lit/docs/install/upgrading.lit
@@ -33,7 +33,7 @@ particular, you'll want to look for any flags that have changed.
   We'll try to minimize this kind of thing in the future.
 
   Lastly, you will want to overwrite the contents of
-  \code{concourse/fly-assets} with the contents from the \link{Github release
+  \code{concourse/fly-assets} with the contents from the \link{GitHub release
   tarball}{https://github.com/concourse/concourse/releases} so users can
   \reference{fly-sync} to the correct version.
 }
@@ -45,7 +45,7 @@ particular, you'll want to look for any flags that have changed.
 
   \section{
     \title{Linux Workers}
-    The Linux tarball from the \link{Github release
+    The Linux tarball from the \link{GitHub release
     page}{https://github.com/concourse/concourse/releases} contains extra
     assets that you will want to ensure are also upgraded at the same time.
     Make sure you overwrite the contents of the following directories:

--- a/lit/docs/install/worker.lit
+++ b/lit/docs/install/worker.lit
@@ -370,7 +370,7 @@ decide much on its own.
       \title{Bundled Resource Types}
 
       Workers come prepackaged with a bundle of resource types. They are
-      included in the tarball from the \link{Github release
+      included in the tarball from the \link{GitHub release
       page}{https://github.com/concourse/concourse/releases} and are part of
       the \link{concourse/concourse
       image}{https://hub.docker.com/r/concourse/concourse}.


### PR DESCRIPTION
# What

This commit replaces "Dockfile" with "Dockerfile" and "Github" with "GitHub".
It's a very minor thing, but it caught my eye nonetheless.