### PR TITLE
Fix indentation of SSH key in resource examples.

### DIFF
--- a/lit/docs/getting-started/resources.lit
+++ b/lit/docs/getting-started/resources.lit
@@ -457,9 +457,9 @@
       # specify branch because it's required for the put step
       branch: master
       private_key: |
-      -----BEGIN OPENSSH PRIVATE KEY-----
-      ...
-      -----END OPENSSH PRIVATE KEY-----
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        ...
+        -----END OPENSSH PRIVATE KEY-----
 
   jobs:
   - name: hello-world-job
@@ -493,9 +493,9 @@
       uri: git@github.com:concourse/examples.git
       branch: master
       private_key: |
-      -----BEGIN OPENSSH PRIVATE KEY-----
-      ...
-      -----END OPENSSH PRIVATE KEY-----
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        ...
+        -----END OPENSSH PRIVATE KEY-----
 
   jobs:
   - name: hello-world-job
@@ -558,9 +558,9 @@
       uri: git@github.com:concourse/examples.git
       branch: master
       private_key: |
-      -----BEGIN OPENSSH PRIVATE KEY-----
-      ...
-      -----END OPENSSH PRIVATE KEY-----
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        ...
+        -----END OPENSSH PRIVATE KEY-----
 
   jobs:
   - name: hello-world-job


### PR DESCRIPTION
I was getting the following error with the previous indentation:

```
$ fly -t tutorial set-pipeline -p hello-world -c hello-world.yml
error: yaml: line 9: could not find expected ':'
```