### PR TITLE
fix typoo at lit/docs/operation/creds/vault.lit

### DIFF
--- a/lit/docs/operation/creds/vault.lit
+++ b/lit/docs/operation/creds/vault.lit
@@ -87,7 +87,7 @@ quite involved.
     default, the templates used are:
 
     \codeblock{bash}{{{
-    CONCOURSE_VAULT_LOOKUP_TEMPLATES=/{{.Team}}/{{.Pipeline}}/{{.Secret}},/{{.Team}}/{{.Secret}}
+    CONCOURSE_VAULT_LOOKUP_TEMPLATES=/{{.Team}}/{{.Pipeline}}/{{.Secret}}/{{.Team}}/{{.Secret}}
     }}}
 
     When secrets are to be looked up, these are evaluated subject to the
@@ -98,7 +98,7 @@ quite involved.
 
     \codeblock{bash}{{{
     CONCOURSE_VAULT_PATH_PREFIX=/secrets
-    CONCOURSE_VAULT_LOOKUP_TEMPLATES=/{{.Team}}/concourse/{{.Pipeline}}/{{.Secret}},/{{.Team}}/concourse/{{.Secret}},/common/{{.Secret}}
+    CONCOURSE_VAULT_LOOKUP_TEMPLATES=/{{.Team}}/concourse/{{.Pipeline}}/{{.Secret}}/{{.Team}}/concourse/{{.Secret}}/common/{{.Secret}}
     }}}
 
     and \code{((password))} is used in team \code{myteam} and pipeline


### PR DESCRIPTION
fix typoo of CONCOURSE_VAULT_LOOKUP_TEMPLATES example at:
https://github.com/concourse/docs/blob/8f37fa6a403681752b6cb21fabd1adcd9b2eab67/lit/docs/operation/creds/vault.lit#L90
and
https://github.com/concourse/docs/blob/8f37fa6a403681752b6cb21fabd1adcd9b2eab67/lit/docs/operation/creds/vault.lit#L101