### PR TITLE
update code example by vito/booklit to concourse/booklit

### DIFF
--- a/lit/docs/observation.lit
+++ b/lit/docs/observation.lit
@@ -44,12 +44,12 @@ your pipelines.
   This can be used to annotate your READMEs with a build status badge like so:
 
   \codeblock{md}{{{
-  ![CI](https://ci.concourse-ci.org/api/v1/teams/main/pipelines/booklit/jobs/unit/badge)
+  ![CI](https://ci.concourse-ci.org/api/v1/teams/main/pipelines/concourse/jobs/unit/badge)
   }}}
 
   ...which should render the following:
 
-  \image{https://ci.concourse-ci.org/api/v1/teams/main/pipelines/booklit/jobs/unit/badge}
+  \image{https://ci.concourse-ci.org/api/v1/teams/main/pipelines/concourse/jobs/unit/badge}
 }
 
 \section{

--- a/lit/docs/pipelines.lit
+++ b/lit/docs/pipelines.lit
@@ -173,7 +173,7 @@ files} which conform to the following schema:
       - name: booklit
         type: git
         source:
-          uri: https://github.com/vito/booklit
+          uri: https://github.com/concourse/booklit
           branch: master
 
       jobs:
@@ -201,7 +201,7 @@ files} which conform to the following schema:
       - name: booklit
         type: git
         source:
-          uri: https://github.com/vito/booklit
+          uri: https://github.com/concourse/booklit
           branch: master
 
       jobs:

--- a/lit/docs/resources.lit
+++ b/lit/docs/resources.lit
@@ -180,7 +180,7 @@ with the following schema.
     \codeblock{yaml}{{{
     name: booklit
     type: git
-    source: {uri: "https://github.com/vito/booklit"}
+    source: {uri: "https://github.com/concourse/booklit"}
     }}}
 
     This could be passed to a job via a \reference{get-step} with
@@ -191,7 +191,7 @@ with the following schema.
     resources:
     - name: booklit
       type: git
-      source: {uri: "https://github.com/vito/booklit"}
+      source: {uri: "https://github.com/concourse/booklit"}
 
     jobs:
     - name: unit

--- a/lit/docs/vars.lit
+++ b/lit/docs/vars.lit
@@ -169,7 +169,7 @@ configured multiple times with different parameters
     - name: booklit
       type: booklit
       source:
-        uri: https://github.com/vito/booklit
+        uri: https://github.com/concourse/booklit
         branch: ((branch))
         private_key: (("github.com".private_key))
 
@@ -215,7 +215,7 @@ configured multiple times with different parameters
             -----BEGIN RSA PRIVATE KEY-----
             # ... snipped ...
             -----END RSA PRIVATE KEY-----
-          uri: https://github.com/vito/booklit
+          uri: https://github.com/concourse/booklit
     }}}
 
     Note that we had to use \code{-y} so that the \code{trigger: true}
@@ -230,7 +230,7 @@ configured multiple times with different parameters
     - name: booklit
       type: booklit
       source:
-        uri: https://github.com/vito/booklit
+        uri: https://github.com/concourse/booklit
         branch: ((branch))
         private_key: (("github.com".private_key))
 
@@ -285,7 +285,7 @@ configured multiple times with different parameters
             -----BEGIN RSA PRIVATE KEY-----
             # ... snipped ...
             -----END RSA PRIVATE KEY-----
-          uri: https://github.com/vito/booklit
+          uri: https://github.com/concourse/booklit
     }}}
 
     Note that we had to use \code{-y} so that the \code{trigger: true}

--- a/lit/index.lit
+++ b/lit/index.lit
@@ -41,7 +41,7 @@
     resources:
     - name: booklit
       type: git
-      source: {uri: "https://github.com/vito/booklit"}
+      source: {uri: "https://github.com/concourse/booklit"}
 
     jobs:
     - name: unit
@@ -82,7 +82,7 @@
   \include-template{pipeline-image}
 
   \italic{This particular pipeline can be found in the \link{Booklit
-  repository}{https://github.com/vito/booklit/blob/8741a4ca3116dcf24c30fedfa78e4aadcaff178a/ci/pipeline.yml}.}
+  repository}{https://github.com/concourse/booklit/blob/8741a4ca3116dcf24c30fedfa78e4aadcaff178a/ci/pipeline.yml}.}
 
   \splash-example{CI under source control}{
     All configuration and administration is done using \reference{fly-cli}{the
@@ -139,7 +139,7 @@
     executing build 1 at http://localhost:8080/builds/1
     initializing
     booklit: 4.74 MiB/s 0s
-    running gopath/src/github.com/vito/booklit/ci/test
+    running gopath/src/github.com/concourse/booklit/ci/test
     fetching dependencies...
     installing ginkgo...
     running tests...


### PR DESCRIPTION
Closes #478 

vito/booklit has switched away from Concourse CI [here](cfa5e17dc5a7531e18245cae1c3501c99b1013b6)

So the examples that refering to booklit/ci/xx.yml will fail.

This PR updates those references to a fork of `booklit` on `Concourse` org that will keep those yml files.