### PR TITLE
Update vault policy example syntax

### DIFF
--- a/lit/docs/operation/creds/vault.lit
+++ b/lit/docs/operation/creds/vault.lit
@@ -170,7 +170,7 @@ quite involved.
 
   \codeblock{hcl}{{{
     path "concourse/*" {
-      policy = "read"
+      capabilities = ["read"]
     }
   }}}
 


### PR DESCRIPTION
Adapt the vault config policy example to the current vault documentation to avoid confusion