### PR TITLE
Add docs on how to test resources outside concourse with docker

### DIFF
--- a/lit/docs/resource-types/implementing.lit
+++ b/lit/docs/resource-types/implementing.lit
@@ -335,7 +335,7 @@ UI, so you should make your output pretty.
   }{
     If the resource you are testing uses \reference{resource-metadata}, you will need to provide the required metadata as environment variables to your \code{docker run} command like so:
     \codeblock{bash}{{{
-      docker run --rm -i -e ATC_EXTERNAL_URL="https://concourse.example.com" -e BUILD_NAME=620 # ... and so on.
+      docker run --rm -i -e ATC_EXTERNAL_URL="https://concourse.example.com" -e BUILD_NAME=620 -v "${PWD}:${PWD}" -w "${PWD}" concourse/git-resource /opt/resource/out . < out-config.json
     }}}
   }
 }

--- a/lit/docs/resource-types/implementing.lit
+++ b/lit/docs/resource-types/implementing.lit
@@ -303,3 +303,39 @@ UI, so you should make your output pretty.
   a man-in-the-middle corporate SSL proxy. (In this way it doesn't feel too
   much like the anti-pattern of hand-tuning workers.)
 }
+
+\section{
+  \title{Testing resources locally using docker}{test-resource-with-docker}
+  To test an already packaged resource (a docker image) outside concourse, you need to:
+  \ordered-list{
+    If, for instance, you are testing the \code{out} behaviour of the \code{git} resource, create a json file with \code{source} configuration of the resource and the \code{params} the \code{put} step expects. Such a file for the \code{git} resource would contain the following (or similar):
+    \codeblock{json}{{{
+      {
+        "source": {
+          "uri": "git://some-uri",
+          "branch": "develop",
+          "private_key": "..."
+        },
+        "params": {
+          "repository": ".",
+          "rebase": true
+        }
+      }
+    }}}
+    Save this file to \code{out-config.json} in your working directory.
+  }{
+    Then run the \code{/opt/resource/out} script with its inputs provided via \code{stdin} like so (using the \code{docker} cli as an example):
+    \codeblock{bash}{{{
+      docker run --rm -i -v "${PWD}:${PWD}" -w "${PWD}" concourse/git-resource /opt/resource/out . < out-config.json
+    }}}
+    \bold{This example needs modification depending on the resource you are testing and your local environment. Specifically:}
+    \ordered-list{
+      If you use the exact configuration in this example, the git resource will print an error about the format of the private key being invalid. Adjust the content \code{out-config.json} as necessary to get it working with your resource.
+    }{
+      If the resource you are testing uses \reference{resource-metadata}, you will need to provide the required metadata as environment variables to your \code{docker run} command like so:
+      \codeblock{bash}{{{
+        docker run --rm -i -e ATC_EXTERNAL_URL="https://concourse.example.com" -e BUILD_NAME=620 # ... and so on.
+      }}}
+    }
+  }
+}

--- a/lit/docs/resource-types/implementing.lit
+++ b/lit/docs/resource-types/implementing.lit
@@ -328,14 +328,14 @@ UI, so you should make your output pretty.
     \codeblock{bash}{{{
       docker run --rm -i -v "${PWD}:${PWD}" -w "${PWD}" concourse/git-resource /opt/resource/out . < out-config.json
     }}}
-    \bold{This example needs modification depending on the resource you are testing and your local environment. Specifically:}
-    \ordered-list{
-      If you use the exact configuration in this example, the git resource will print an error about the format of the private key being invalid. Adjust the content \code{out-config.json} as necessary to get it working with your resource.
-    }{
-      If the resource you are testing uses \reference{resource-metadata}, you will need to provide the required metadata as environment variables to your \code{docker run} command like so:
-      \codeblock{bash}{{{
-        docker run --rm -i -e ATC_EXTERNAL_URL="https://concourse.example.com" -e BUILD_NAME=620 # ... and so on.
-      }}}
-    }
+  }
+  \warn{This example needs modification depending on the resource you are testing and your local environment. See the notes below for details.}
+  \ordered-list{
+    If you use the exact configuration in this example, the git resource will print an error about the format of the private key being invalid. Adjust the content \code{out-config.json} as necessary to get it working with your resource.
+  }{
+    If the resource you are testing uses \reference{resource-metadata}, you will need to provide the required metadata as environment variables to your \code{docker run} command like so:
+    \codeblock{bash}{{{
+      docker run --rm -i -e ATC_EXTERNAL_URL="https://concourse.example.com" -e BUILD_NAME=620 # ... and so on.
+    }}}
   }
 }


### PR DESCRIPTION
# Why
I have from time to time dealt with a broken `check` or put on Concourse and needed to debug what's going on with the resource locally (outside concourse). A lot of these times, `fly check-resource` and `fly check-resource-type` hasn't been sufficient testing tools because the problems I had were with the way I configured the resource or a bug within the resource itself. 

To tighten the feedback loop between making a resource config change and seeing if it works, I needed to test the resources `check`, `in`, `out` on my machine. This, as opposed to having the check the changes into version control and waiting for the pipeline for run, only to find out minutes later that I misconfigured it again!.

Every time I have had to do this, I spent a significant amount of time translating the docs on [resource type internals](https://concourse-ci.org/implementing-resource-types.html) into the correct `docker` invocation. I went through this again recently and realized it would be very nice to have docs on how to do this right on [that resource internals page](https://concourse-ci.org/implementing-resource-types.html).

# What
1. Add a section to the [implementing a resource type](https://concourse-ci.org/implementing-resource-types.html) docs page talking about how to test a resource outside concourse using docker. See a screenshot of the rendered additions below.

![Screen Shot 2022-03-18 at 6 57 02 PM](https://user-images.githubusercontent.com/3718698/159098089-96d323f7-a01a-4ee7-898e-ac098a62fe15.png)
