### PR TITLE
Update doc for https://github.com/concourse/concourse/pull/8184

### DIFF
--- a/lit/docs/install/worker.lit
+++ b/lit/docs/install/worker.lit
@@ -296,7 +296,7 @@ decide much on its own.
   \section{
     \title{Team Workers}
 
-    If you want to isolate \bold{all workloads} for a
+    If you want to isolate \reference{complications-with-reusing-containers}{\bold{all workloads}} for a
     \reference{managing-teams}{team} then you can configure a worker to belong
     to a single team like so:
 

--- a/lit/docs/operation/global-resources.lit
+++ b/lit/docs/operation/global-resources.lit
@@ -52,14 +52,15 @@ instead associated to an anonymous 'resource config' i.e. its
       which is workers belonging to a team and workers with tags.
 
       If a resource has \reference{schema.resource.tags} configured, \italic{and} the
-      resource's check interval ends up acquiring the checking lock, a new
-      container will be created on a worker matching the appropriate tags, even
-      if a check container already exists for the same resource config
-      elsewhere.
+      resource's check interval ends up acquiring the checking lock, if a check
+      container already exists for the same resource config elsewhere, it will reuse
+      the container, otherwise a container will be created on a worker matching
+      the appropriate tags.
 
       Similarly, if a team has its own workers, and their check interval ended
-      up acquiring the lock, a new container will be created on the team's
-      workers, rather than re-using a container from the shared worker pool.
+      up acquiring the lock, it will try to re-use a container from the shared
+      worker pool, rather than creating a new container will be created on the
+      team's workers.
 
       This is a bit complicated to reason about and we plan to stop re-using
       \code{check} containers to simplify all of this. See \ghissue{3079} for

--- a/lit/docs/operation/global-resources.lit
+++ b/lit/docs/operation/global-resources.lit
@@ -53,13 +53,13 @@ instead associated to an anonymous 'resource config' i.e. its
 
       If a resource has \reference{schema.resource.tags} configured, \italic{and} the
       resource's check interval ends up acquiring the checking lock, if a check
-      container already exists for the same resource config elsewhere, it will reuse
+      container already exists with the same resource config elsewhere, it will reuse
       the container, otherwise a container will be created on a worker matching
       the appropriate tags.
 
       Similarly, if a team has its own workers, and their check interval ended
-      up acquiring the lock, it will try to re-use a container from the shared
-      worker pool, rather than creating a new container will be created on the
+      up acquiring the lock, it will try to re-use a container with the same resource
+      config from the shared worker pool, rather than creating a new container on the
       team's workers.
 
       This is a bit complicated to reason about and we plan to stop re-using

--- a/lit/docs/operation/global-resources.lit
+++ b/lit/docs/operation/global-resources.lit
@@ -1,4 +1,4 @@
-\title{Global Resources\aux{ (experimental)}}{global-resources}
+\title{Global Resources}{global-resources}
 
 \use-plugin{concourse-docs}
 
@@ -46,7 +46,7 @@ instead associated to an anonymous 'resource config' i.e. its
     running the checks for that resource configuration.
 
     \section{
-      \title{Complications with reusing containers}
+      \title{Complications with reusing containers}{complications-with-reusing-containers}
 
       There is an exception to sharing check containers within a deployment,
       which is workers belonging to a team and workers with tags.


### PR DESCRIPTION
When global resource is enabled, a check container may run on any worker.