### PR TITLE
Add Electric UI to list of users

### DIFF
--- a/lit/ecosystem.lit
+++ b/lit/ecosystem.lit
@@ -42,6 +42,8 @@ how many people do things continuously with Concourse.
   }{
     \link{Cycloid}{https://www.cycloid.io}
   }{
+    \link{Electric UI}{https://electricui.com}
+  }{
     \link{EngineerBetter}{https://www.engineerbetter.com}
   }{
     \link{Express Scripts}{https://www.express-scripts.com}


### PR DESCRIPTION
Hi,

We've been using Concourse since early 2021 and been pretty happy with it.

For reference, we've tweaked/forked [some resources (viewable on GitHub)](https://github.com/orgs/electricui/repositories?q=concourse), and here's a vague snapshot of how we've been using it:

![image](https://user-images.githubusercontent.com/460325/189670060-4915f5c2-8296-428d-9809-c61942ce8ba2.png)

![image](https://user-images.githubusercontent.com/460325/189670311-0996486b-45a1-4373-b776-430a59237ed7.png)


Thanks!