### PR TITLE
Fix a few typos

### DIFF
--- a/lit/docs/guides/container-images.lit
+++ b/lit/docs/guides/container-images.lit
@@ -216,7 +216,7 @@
     \title{Publish the Container Image}
 
     To push the container image add a \reference{put-step}{put step} to our job
-    plan and tell the regstry-image resource where the tarball of the container
+    plan and tell the registry-image resource where the tarball of the container
     image is.
 
     The put step will push the container image using the information defined

--- a/lit/docs/guides/pipeline-guides.lit
+++ b/lit/docs/guides/pipeline-guides.lit
@@ -405,7 +405,7 @@
     \codeblock{bash}{{
     fly -t tutorial set-pipeline -p parallel-artifacts -c parallel-artifacts.yml
     fly -t tutorial unpause-pipeline -p parallel-artifacts
-    fly -t tutorial trigger-job --job parallel-artifacts/writing-in-parallel --watch
+    fly -t tutorial trigger-job --job parallel-artifacts/writing-to-the-same-output-in-parallel --watch
     fly -t tutorial trigger-job --job parallel-artifacts/writing-to-the-same-output-serially --watch
     }}
   }

--- a/lit/docs/guides/pipeline-guides.lit
+++ b/lit/docs/guides/pipeline-guides.lit
@@ -781,7 +781,7 @@
     By default all \reference{jobs} only run when manually triggered. That
     means a user has to run \reference{fly-trigger-job} or click the plus
     button in the web interface for a job to run. A job only runs automatically
-    if one of it's resources has the
+    if one of its resources has the
     \reference{schema.get.trigger}{\code{trigger: true}} parameter
     set.
 

--- a/lit/docs/guides/pipeline-guides.lit
+++ b/lit/docs/guides/pipeline-guides.lit
@@ -243,7 +243,7 @@
               - |
                 ls -lah
                 date > ./the-output/file
-      - task: read-ouput-from-previous-step
+      - task: read-output-from-previous-step
         config:
           platform: linux
           image_resource: *busybox
@@ -340,7 +340,7 @@
                   date > ./the-output/file2
       # run this job multiple times to see which
       # previous task wins each time
-      - task: read-ouput-from-previous-step
+      - task: read-output-from-previous-step
         config:
           platform: linux
           image_resource: *busybox
@@ -351,7 +351,7 @@
             args:
               - -cx
               - |
-                ls -lah ./the-ouput
+                ls -lah ./the-output
                 echo "Get ready to error!"
                 cat ./the-output/file1 ./the-output/file2
 
@@ -383,7 +383,7 @@
               - |
                 ls -lah
                 date > ./the-output/file2
-      - task: read-ouput-from-previous-step
+      - task: read-output-from-previous-step
         config:
           platform: linux
           image_resource: *busybox
@@ -394,7 +394,7 @@
             args:
               - -cx
               - |
-                ls -lah ./the-ouput
+                ls -lah ./the-output
                 echo "Get ready to error! file1 will never exist"
                 cat ./the-output/file1 ./the-output/file2
     }}
@@ -472,7 +472,7 @@
                 ls -lah
                 date > ./the-output/file
       # this task expects the artifact `demo-disk` so no mapping is needed
-      - task: read-ouput-from-previous-step
+      - task: read-output-from-previous-step
         config:
           platform: linux
           image_resource: *busybox
@@ -594,7 +594,7 @@
               - |
                 ls -lah
                 date > ./the-output/file2
-      - task: read-ouput-from-previous-step
+      - task: read-output-from-previous-step
         config:
           platform: linux
           image_resource:

--- a/lit/docs/guides/pipeline-guides.lit
+++ b/lit/docs/guides/pipeline-guides.lit
@@ -787,7 +787,7 @@
 
     Therefore, in order to create a gated job in a pipeline you simply need to
     create a job that can only be manually triggered. That means not setting
-    \code{trigger: true} for any of the jobs \reference{get-step}{get steps}.
+    \code{trigger: true} for any of the jobs' \reference{get-step}{get steps}.
 
     \codeblock{yaml}{{
 jobs:


### PR DESCRIPTION
This is just a minor correction to one of the Bash commands in the pipelines guide as well as a few other corrections to misspellings.