### PR TITLE
fix docs for BUILD_CREATED_BY metadata field

### DIFF
--- a/lit/docs/resource-types/implementing.lit
+++ b/lit/docs/resource-types/implementing.lit
@@ -256,7 +256,8 @@ UI, so you should make your output pretty.
     \definition{\code{$BUILD_CREATED_BY}}{
       The username that created the build. By default it is not available. See
       \reference{schema.resource.expose_build_created_by}{\code{expose_build_created_by}}
-      for how to opt in.
+      for how to opt in. This metadata field is not made available to the
+      \reference{get-step}.
     }
   }{
     \definition{\code{$ATC_EXTERNAL_URL}}{

--- a/lit/docs/resources.lit
+++ b/lit/docs/resources.lit
@@ -106,9 +106,9 @@ with the following schema.
 
   \optional-attribute{expose_build_created_by}{boolean}{
     \italic{Default \code{false}.} If set to \code{true}, environment variable
-    \reference{resource-metadata}{\code{BUILD_CREATED_BY}} will be available
-    in the metadata of a \reference{get-step}{get step} or
-    \reference{put-step}{put step}.
+    \reference{resource-metadata}{\code{BUILD_CREATED_BY}} will be available in
+    the metadata of a \reference{put-step}{put step}. This field is not made
+    available to the \reference{get-step}.
   }
 
   \optional-attribute{tags}{[string]}{


### PR DESCRIPTION
this field is not exposed to get steps. See pr discussion here: https://github.com/concourse/concourse/pull/6369#discussion_r565558527