### PR TITLE
remove Trulla and update EngineerBetter

### DIFF
--- a/lit/ecosystem.lit
+++ b/lit/ecosystem.lit
@@ -119,7 +119,7 @@ how many people do things continuously with Concourse.
   }{
     \link{Cycloid}{https://www.cycloid.io}
   }{
-    \link{EngineerBetter}{https://www.engineerbetter.com}
+    \link{Container Solutions}{https://www.container-solutions.com/}
   }{
     \link{Gstack}{https://www.gstack.io}
   }{
@@ -130,8 +130,6 @@ how many people do things continuously with Concourse.
     \link{Stark & Wayne}{https://www.starkandwayne.com}
   }{
     \link{SuperOrbital}{https://www.superorbital.io}
-  }{
-    \link{TRULLLA Software}{https://www.trullla.com}
   }{
     \link{VMware Tanzu Labs}{https://tanzu.vmware.com/labs}
   }


### PR DESCRIPTION
Trulla goes to a blank landing page with only a logo.

EngineerBetter was acquired and now redirects to Container Solutions, which still appears to use Concourse based on recent blog posts.