### PR TITLE
update task config docs to reflect how task input.Path currently works

### DIFF
--- a/lit/docs/tasks.lit
+++ b/lit/docs/tasks.lit
@@ -119,8 +119,10 @@ A task's configuration specifies the following:
         The path where the input will be placed. If not specified, the input's
         \code{name} is used.
 
-        Paths are relative to the working directory of the task. Absolute paths
-        are not respected.
+        Paths are relative to the working directory of the task unless an
+        absolute path is given. An absolute path is any path that starts with a
+        forward slash \code{/}. We recommend only using relative paths unless
+        you have a strong technical reason to use absolute paths.
       }
 
       \optional-attribute{optional}{boolean}{
@@ -151,7 +153,10 @@ A task's configuration specifies the following:
         The path to a directory where the output will be taken from. If not
         specified, the output's \code{name} is used.
 
-        Paths are relative to the working directory of the task. Absolute paths are not respected.
+        Paths are relative to the working directory of the task unless an
+        absolute path is given. An absolute path is any path that starts with a
+        forward slash \code{/}. We recommend only using relative paths unless
+        you have a strong technical reason to use absolute paths.
       }
     }
   }


### PR DESCRIPTION
concourse/concourse#6597 changed how the `path` works in Concourse and allowed users to specify an absolute path. The exact commit is this one:

https://github.com/concourse/concourse/commit/2ba0164e8be66100e24c727bd51f04c625398231

This has been the current behaviour since 7.5.0 so I don't think there's any going back on this behaviour now. I think it may make caching stuff a lot easier for folks to work with. I'm generally in favour of this change which I think was kinda snuck in. It was a massive PR.