### PR TITLE
Make OIDC permissions a bit clearer

### DIFF
--- a/lit/docs/auth/configuring/generic-oidc.lit
+++ b/lit/docs/auth/configuring/generic-oidc.lit
@@ -78,8 +78,8 @@ issuer URL rather than auth/token/userinfo URLs.
   \code{CONCOURSE_OIDC_USER_NAME_KEY} is unique. If they're not, then it's
   possible for users to impersonate each other}
 
-  OIDC users and groups can be authorized for a team by passing the following
-  flags to \reference{fly-set-team}:
+  OIDC users and groups can be authorized for a team by passing one or more
+  of the following flags to \reference{fly-set-team}:
 
   \definitions{
     \definition{\code{--oidc-user=USERNAME}}{
@@ -103,7 +103,9 @@ issuer URL rather than auth/token/userinfo URLs.
   \codeblock{bash}{{{
   $ fly set-team -n my-team \
       --oidc-user my-username \
-      --oidc-group my-group
+      --oidc-user another-username \
+      --oidc-group my-group \
+      --oidc-group my-other-group
   }}}
 
   ...or via \code{--config} for \reference{setting-roles}{setting user roles}:
@@ -112,9 +114,12 @@ issuer URL rather than auth/token/userinfo URLs.
   roles:
   - name: member
     oidc:
-      users: ["my-username"]
-      groups: ["my-groups"]
+      users: ["my-username", "another-username"]
+      groups: ["my-group", "my-other-group"]
   }}}
+
+  Both users and groups are optional. You may opt to only provide privileges
+  based on membership to a group and not to any user explicitly and vice versa.
 
   \section{
     \title{Configuring \code{main} Team Authorization}


### PR DESCRIPTION
I was doing some OIDC work this morning with Concourse and found that the documentation wasn't entirely clear.

```console
$ fly -t main get-team -n blah
name/role     users  groups
blah/owner  none   oidc:permissions - concourse admins,oidc:engineering
```

Going off of `get-team` as a reference, it surfaces a comma separated list. Given that the docs don't explicitly suggest that you can pass `--oidc-group` flags multiple times as input, I erroneously passed a comma separated list which nullified all permissions (as the evaluated string was not a valid group).

Given that, I've tried to provide some hints for future readers on how this section works. I should note that I haven't used the `--config` stuff but assume it takes an array of strings. I have used `set-team` though which does take multiple flags.

It also wasn't clear whether I had to provide a user alongside a group or if both were optional so I mentioned that as well.