### PR TITLE
add Vault KV mount cache to doc

### DIFF
--- a/docs/docs/operation/creds/vault.md
+++ b/docs/docs/operation/creds/vault.md
@@ -143,6 +143,17 @@ vault policy write concourse ./concourse-policy.hcl
 This configuration will allow Concourse to read all credentials under `/concourse`. This should match your configured
 path prefix.
 
+### Enabling KV mount caching
+
+When Concourse looks up secrets in Vault, it needs to determine which KV mount version (v1 or v2) contains the secret.
+By default, this information is fetched from Vault for each lookup. Enabling KV mount caching allows this information to be fetched once and reused for subsequent lookups, significantly reducing the number of Vault API calls.
+
+To enable KV mount caching, set the following environment variable on the `web` node:
+
+```properties
+CONCOURSE_VAULT_ENABLE_KV_MOUNT_CACHE=true
+```
+
 ## Authenticating with Vault
 
 There are many ways to authenticate with a Vault server. The `web` node can be configured with either a token or an

--- a/docs/docs/vars.md
+++ b/docs/docs/vars.md
@@ -417,7 +417,13 @@ used just like resource types.
 
                 When retrying during authentication, start with this retry interval. The interval will increase 
                 exponentially until `auth_retry_max` is reached.
-    
+            
+            ??? info "**`enable_kv_mount_cache`**: [`boolean`](config-basics.md#boolean-schema)"
+
+                By default, this feature is disabled. When disabled, Concourse queries Vault on every secret lookup to determine whether the secret resides in a KV version 1 or version 2 mount, as this affects how the secret is retrieved.
+
+                When enabled, KV mount metadata is cached. This allows Concourse to fetch mount information once and reuse it for subsequent lookups, reducing the number of Vault API calls and improving performance.
+                    
     === "Dummy"
     
         ??? warning "**`type`**: `dummy`"


### PR DESCRIPTION
# Changes proposed in this pull request

Because of upstream change  https://github.com/concourse/concourse/pull/9530
I guess it should be merged after release to avoid confusions.

Changes extend documentation under "Operations" -> "The Vault credential manager" -> "Configuring the secrets engine":
<img width="870" height="330" alt="image" src="https://github.com/user-attachments/assets/63c828af-1aa3-446c-8890-6668339f71be" />

As well as in `var_sources`:
<img width="810" height="309" alt="image" src="https://github.com/user-attachments/assets/808cdaa7-6ca1-4d79-8a3e-0e753f7bfee9" />

